### PR TITLE
Persist and restart plugins

### DIFF
--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -23,6 +23,14 @@ class PluginsController extends EventEmitter {
     this.getApi = opts.getApi
   }
 
+ runExistingPlugins () {
+    const plugins = this.store.getState().plugins
+    Object.values(plugins).forEach(({ pluginName, requestedPermissions, sourceCode }) => {
+      const ethereumProvider = this.setupProvider(pluginName, async () => { return {name: pluginName } }, true)
+      this._startPlugin(pluginName, requestedPermissions, sourceCode, ethereumProvider)
+    })
+  }
+
   get (pluginName) {
     return this.store.getState().plugins[pluginName]
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -279,6 +279,7 @@ module.exports = class MetamaskController extends EventEmitter {
     },
     initState.PermissionsController)
 
+    this.pluginsController.runExistingPlugins()
 
     this.store.updateStructure({
       AppStateController: this.appStateController.store,


### PR DESCRIPTION
This PR makes some fixes to the plugin and metamask controllers to ensure that:
- plugins are persisted to state
- new plugins are only stored to state if permission to store them is granted
- if a plugin exists in state, it is used when permission to install is requested, instead of fetching it again
- existing plugins are run on MetaMask's initialization