### PR TITLE
Expose app keys to plugin

### DIFF
--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -19,6 +19,7 @@ class PluginsController extends EventEmitter {
     this._blockTracker = opts._blockTracker
     this._getAccounts = opts._getAccounts
     this.getApi = opts.getApi
+    this.getAppKeyForDomain = opts.getAppKeyForDomain
 
     this.rpcMessageHandlers = new Map()
   }
@@ -164,7 +165,11 @@ class PluginsController extends EventEmitter {
       ...this.getApi(),
     }
     const registerRpcMessageHandler = this._registerRpcMessageHandler.bind(this, pluginName)
-    const apisToProvide = { onMetaMaskEvent, registerRpcMessageHandler }
+    const apisToProvide = {
+      onMetaMaskEvent,
+      registerRpcMessageHandler,
+      getAppKey: () => this.getAppKeyForDomain(pluginName),
+    }
     apiList.forEach(apiKey => {
       apisToProvide[apiKey] = possibleApis[apiKey]
     })

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -270,6 +270,7 @@ module.exports = class MetamaskController extends EventEmitter {
       _getAccounts: this.keyringController.getAccounts.bind(this.keyringController),
       getApi: this.getPluginsApi.bind(this),
       initState: initState.PluginsController,
+      getAppKeyForDomain: this.getAppKeyForDomain.bind(this),
     })
 
     this.permissionsController = new PermissionsController({
@@ -1319,6 +1320,14 @@ module.exports = class MetamaskController extends EventEmitter {
     if (cb && typeof cb === 'function') {
       cb(null, this.getState())
     }
+  }
+
+  async getAppKeyForDomain (domain) {
+    const keyringController = this.keyringController
+    const accounts = await keyringController.getAccounts()
+    const firstAccount = accounts[0]
+    const privateAppKey = await keyringController.exportAppKeyForAddress(firstAccount, domain)
+    return privateAppKey
   }
 
   // ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "eth-json-rpc-filters": "^4.1.0",
     "eth-json-rpc-infura": "^4.0.1",
     "eth-json-rpc-middleware": "^4.2.0",
-    "eth-keyring-controller": "^5.1.0",
+    "eth-keyring-controller": "^5.2.0",
     "eth-ledger-bridge-keyring": "^0.2.0",
     "eth-method-registry": "^1.2.0",
     "eth-phishing-detect": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@agoric/make-hardener@^0.0.6":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.6.tgz#5903748a71381bc37e23d571390aaff9973c37b2"
-  integrity sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ==
-
 "3box-orbitdb-plugins@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/3box-orbitdb-plugins/-/3box-orbitdb-plugins-1.0.5.tgz#eec6f6a553b316272c3c71e58c141241459280ed"
@@ -51,6 +46,11 @@
     did-jwt "^0.1.3"
     did-resolver "0.0.6"
     ipfs-did-document "^1.2.3"
+
+"@agoric/make-hardener@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@agoric/make-hardener/-/make-hardener-0.0.6.tgz#5903748a71381bc37e23d571390aaff9973c37b2"
+  integrity sha512-OpZcNx/7bhHar0iuQ6D+FKYCMMxqKvYs4aC/bB5v/ffZaSM5sNAl98DnGL1mD9NSyZLGzAZ7D5XwJpe37BMldQ==
 
 "@babel/code-frame@7.0.0":
   version "7.0.0"
@@ -9766,13 +9766,14 @@ eth-hd-keyring@^2.0.0:
     events "^1.1.1"
     xtend "^4.0.1"
 
-eth-hd-keyring@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-2.1.0.tgz#da93224f791fb1d9220598f7c96f04181dff6ace"
-  integrity sha512-1ZcPmj4h18tmwG7RIturC2lpeimuiAyUGW9Ic5ztCFNeRAcfiQ3ic7sENWhzqbSgth9xkAMIHqM8IY31VJviZg==
+eth-hd-keyring@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eth-hd-keyring/-/eth-hd-keyring-3.1.0.tgz#9c7f5e5df6588cd0ffad39feb861e241db69a6be"
+  integrity sha512-nVLurn1eC97/IRtLATMXTGU3J4VmgREGl5WPhcHy+YehGoUImYxxeuUVBMMozFapHNY3JFfNgA06N4LHl5rWbQ==
   dependencies:
     bip39 "^2.2.0"
-    eth-sig-util "^2.0.1"
+    eth-sig-util "^2.4.4"
+    eth-simple-keyring "^3.1.0"
     ethereumjs-abi "^0.6.5"
     ethereumjs-util "^5.1.1"
     ethereumjs-wallet "^0.6.0"
@@ -9882,17 +9883,17 @@ eth-keyring-controller@^5.0.1:
     obs-store "^4.0.3"
     promise-filter "^1.1.0"
 
-eth-keyring-controller@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.1.0.tgz#1dbe539f6ca483d6f2fa16b33b00d66eeb2de974"
-  integrity sha512-NCXzYIBHJo5o8XoyPdGRLRLTi2pitJKlZPcDO+Un4wbt3djrvWH8adopLH+kNw9zUfk2C5OQqUQ4/UibSvanxA==
+eth-keyring-controller@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eth-keyring-controller/-/eth-keyring-controller-5.2.0.tgz#be292fb92a9b92beb45feb77e7d38639e3b5ded9"
+  integrity sha512-Dr/foUCwr8ZTETkMRBlZffu4FwTWubf3YQ8SyseCZd0VtUXTNAxum76HTuLpcXVseIwK2mwtiiN4Cmt/taL4jQ==
   dependencies:
     bip39 "^2.4.0"
     bluebird "^3.5.0"
     browser-passworder "^2.0.3"
-    eth-hd-keyring "^2.1.0"
+    eth-hd-keyring "^3.1.0"
     eth-sig-util "^1.4.0"
-    eth-simple-keyring "^2.1.0"
+    eth-simple-keyring "^3.3.0"
     ethereumjs-util "^5.1.2"
     loglevel "^1.5.0"
     obs-store "^4.0.3"
@@ -10010,6 +10011,18 @@ eth-sig-util@^2.1.0:
     tweetnacl "^1.0.0"
     tweetnacl-util "^0.15.0"
 
+eth-sig-util@^2.4.3, eth-sig-util@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.4.4.tgz#8804ead83de8648bcf81eadbfac1e3ccdd360aea"
+  integrity sha512-iWGqEJwsUMgtk8AqQQqIDTjMz+pW8s2Sq8gN640dh9U9HoEFQJO3m6ro96DgV6hMB2LYu8F5812LQyynOgCbEw==
+  dependencies:
+    buffer "^5.2.1"
+    elliptic "^6.4.0"
+    ethereumjs-abi "0.6.5"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.0"
+    tweetnacl-util "^0.15.0"
+
 eth-simple-keyring@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-2.0.0.tgz#ef1e97c4aebb7229dce9c0ec5cc84efcd3a76395"
@@ -10022,12 +10035,12 @@ eth-simple-keyring@^2.0.0:
     events "^1.1.1"
     xtend "^4.0.1"
 
-eth-simple-keyring@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-2.1.0.tgz#bfff8f7c438a9b5164e995db1cccbbdb9e27752f"
-  integrity sha512-31emUxGHOVhYzlPoEGyfrn1Usi2ZI9qDqMnDHwG0R0HdIuF/I10qlf401MkiD9lcMDuvgJkLpqqAvGxrKrFCwA==
+eth-simple-keyring@^3.1.0, eth-simple-keyring@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eth-simple-keyring/-/eth-simple-keyring-3.3.0.tgz#a62ce779d35768e0ac01ed0b38ffbdbbd874ac79"
+  integrity sha512-CBUtcBPxZkS+qKZyuJ0lBj1ACnn1RJH6aOfGvgHo38glkQ6dHN0LRYxdzwh9uzfLMX+XzEGwJTDz4Srxcr8+iA==
   dependencies:
-    eth-sig-util "^2.0.1"
+    eth-sig-util "^2.4.3"
     ethereumjs-abi "^0.6.5"
     ethereumjs-util "^5.1.1"
     ethereumjs-wallet "^0.6.0"
@@ -15528,7 +15541,7 @@ json-rpc-engine@^3.4.0, json-rpc-engine@^3.6.0:
     promise-to-callback "^1.0.0"
     safe-event-emitter "^1.0.1"
 
-json-rpc-engine@^5.0.0:
+json-rpc-engine@^5.0.0, json-rpc-engine@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.1.4.tgz#c18d1959eb175049fa7301d4866931ae2f879e47"
   integrity sha512-nBFWYJ1mvlZL7gqq0M9230SxedL9CbSYO1WgrFi/C1Zo+ZrHUZWLRbr7fUdlLt9TC0G+sf/aEUeuJjR2lHsMvA==
@@ -15545,16 +15558,6 @@ json-rpc-engine@^5.1.3:
   dependencies:
     async "^2.0.1"
     eth-json-rpc-errors "^1.0.1"
-    promise-to-callback "^1.0.0"
-    safe-event-emitter "^1.0.1"
-
-json-rpc-engine@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-5.1.4.tgz#c18d1959eb175049fa7301d4866931ae2f879e47"
-  integrity sha512-nBFWYJ1mvlZL7gqq0M9230SxedL9CbSYO1WgrFi/C1Zo+ZrHUZWLRbr7fUdlLt9TC0G+sf/aEUeuJjR2lHsMvA==
-  dependencies:
-    async "^2.0.1"
-    eth-json-rpc-errors "^1.1.0"
     promise-to-callback "^1.0.0"
     safe-event-emitter "^1.0.1"
 


### PR DESCRIPTION
Via a method `wallet.getAppKey()`, which returns a promise, which resolves to a hex-encoded 32 byte string.