### PR TITLE
Plugin reloading

### DIFF
--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -105,7 +105,7 @@ function getExternalRestrictedMethods (permissionsController) {
           const origin = req.method.substr(14)
 
           const prior = permissionsController.pluginsController.get(origin)
-          if (!prior) {
+          if (false && !prior) {
             await permissionsController.pluginsController.add(origin)
           }
 

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -61,7 +61,7 @@ class PluginsController extends EventEmitter {
     const plugins = this.store.getState().plugins
 
     let plugin
-    if (plugins[pluginName]) {
+    if (false && plugins[pluginName]) {
       plugin = plugins[pluginName]
     } else {
       plugin = await fetch(sourceUrl)


### PR DESCRIPTION
This PR ensures that plugins are freshly fetched whenever they are requested. This will make plugin development easier, but will be changed before going to production.

The PR also ensures that plugin state is persisted across different installations of the plugin.