### PR TITLE
Get plugin system working with plugins as per mm-plugin api on commit 45d262a

### DIFF
--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -98,14 +98,14 @@ function getExternalRestrictedMethods (permissionsController) {
       },
     },
 
-    'wallet_plugin_': {
+    'wallet_plugin_*': {
       description: 'Connect to plugin $1, and install it if not available yet.',
       method: async (req, res, _next, end, engine) => {
         try {
           const origin = req.method.substr(14)
 
           const prior = permissionsController.pluginsController.get(origin)
-          if (false && !prior) {
+          if (!prior) {
             await permissionsController.pluginsController.add(origin)
           }
 
@@ -120,7 +120,7 @@ function getExternalRestrictedMethods (permissionsController) {
 
           // Handler is an async function that takes an origin string and a request object.
           // It should return the result it would like returned to the reqeustor as part of response.result
-          res.result = await handler(requestor, req)
+          res.result = await handler(requestor, req.params[0])
           return end()
 
         } catch (err) {

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -65,8 +65,22 @@ class PluginsController extends EventEmitter {
     if (false && plugins[pluginName]) {
       plugin = plugins[pluginName]
     } else {
+      let _requestedPermissions
       plugin = await fetch(sourceUrl)
-        .then(pluginRes => pluginRes.json())
+        .then(pluginRes => {
+          return pluginRes.json()
+        })
+        .then(({ web3Wallet: { bundle, requestedPermissions } }) => {
+           _requestedPermissions = requestedPermissions
+          return fetch(bundleUrl)
+        })
+        .then(bundleRes => bundleRes.text())
+        .then(sourceCode => {
+          return {
+            sourceCode,
+            requestedPermissions: _requestedPermissions,
+          }
+        })
         .catch(err => console.log('add plugin error:', err))
     }
 
@@ -75,37 +89,42 @@ class PluginsController extends EventEmitter {
 
     const ethereumProvider = this.setupProvider(pluginName, async () => { return {name: pluginName } }, true)
 
-    return ethereumProvider.sendAsync({
-      method: 'wallet_requestPermissions',
-      jsonrpc: '2.0',
-      params: [{ ['eth_runPlugin_' + pluginName]: {}, ...requestedPermissions }, { sourceCode, ethereumProvider }],
-    }, (err1, res1) => {
-      if (err1) return err1
+    return new Promise ((resolve, reject) => {
+      ethereumProvider.sendAsync({
+        method: 'wallet_requestPermissions',
+        jsonrpc: '2.0',
+        params: [{ ['eth_runPlugin_' + pluginName]: {}, ...requestedPermissions }, { sourceCode, ethereumProvider }],
+      }, (err1, res1) => {
+        console.log('err1, res1', err1, res1)
+        if (err1) reject(err1)
 
-      const capabilities = res1.result.map(cap => cap.parentCapability).filter(cap => !cap.startsWith('eth_runPlugin_'))
+        const capabilities = res1.result.map(cap => cap.parentCapability).filter(cap => !cap.startsWith('eth_runPlugin_'))
 
-      if (!plugins[pluginName]) {
-        const newPlugin = {
-          handleRpcRequest: async (result) => {
-            return Promise.resolve(result)
-          },
-          pluginName,
-          sourceCode,
-          requestedPermissions: capabilities,
+        if (!plugins[pluginName]) {
+          const newPlugin = {
+            handleRpcRequest: async (result) => {
+              return Promise.resolve(result)
+            },
+            pluginName,
+            sourceCode,
+            requestedPermissions: capabilities,
+          }
+
+          const newPlugins = {...plugins, [pluginName]: newPlugin}
+
+          this.store.updateState({
+            plugins: newPlugins,
+          })
         }
 
-        const newPlugins = {...plugins, [pluginName]: newPlugin}
-
-        this.store.updateState({
-          plugins: newPlugins,
+        ethereumProvider.sendAsync({
+          method: 'eth_runPlugin_' + pluginName,
+          params: [{ requestedPermissions: capabilities, sourceCode, ethereumProvider }],
+        }, (err2, res2) => {
+          console.log('plugin.add err2, res2', err2, res2)
+          if (err2) reject(err2)
+          resolve(res2)
         })
-      }
-
-      ethereumProvider.sendAsync({
-        method: 'eth_runPlugin_' + pluginName,
-        params: [{ requestedPermissions: capabilities, sourceCode, ethereumProvider }],
-      }, (err2, res2) => {
-        console.log('plugin.add err2, res2', err2, res2)
       })
     })
   }
@@ -184,8 +203,12 @@ class PluginsController extends EventEmitter {
     const sessedPlugin = s.evaluate(sourceCode, {
       wallet: ethereumProvider,
       console, // Adding console for now for logging purposes.
+      BigInt,
+      window: {
+        crypto,
+      },
     })
-    sessedPlugin.run()
+    sessedPlugin()
     this._setPluginToActive(pluginName)
     return true
   }

--- a/ui/app/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.container.js
@@ -13,8 +13,7 @@ const mapStateToProps = (state) => {
   const requestedPermissionsKeys = Object.keys(requestedPermissions)
   const permissionsDescriptions = getPermissionsDescriptions(state)
   const requestedPermissionsDescriptions = requestedPermissionsKeys.reduce((acc, requestedPermissionKey) => {
-    const isWildCardPermission = requestedPermissionKey.match(/([A-z0-9]+_[A-z0-9]+_)([A-z0-9]+)/)
-
+    const isWildCardPermission = requestedPermissionKey.match(/([A-z0-9]+_[A-z0-9]+_)([A-z0-9\:\/\.]+)/)
 
     let permissionDescription
 


### PR DESCRIPTION
The PR includes the following fixes:
- adds an `'*'` to the name of the `wallet_plugin_` restricted method
- restores the add of plugins if no prior one exists
- fixes the parameters passed to the `handler`
- modifies the fetching of plugins to work with the new use of package.json
- changes `pluginController.add` to return a promise, allowing for correct functioning of the `wallet_plugin_*` method
- passes some extra required globals to SES
- updates call on sessified code to reflect latest api from `mm-plugin`
- updates frontend code to handle urls as plugin names