### PR TITLE
Fix missing permissions descriptions in prompt

### DIFF
--- a/app/scripts/controllers/permissions/permissions.js
+++ b/app/scripts/controllers/permissions/permissions.js
@@ -209,8 +209,17 @@ class PermissionsController {
    */
   _initializePermissions (restoredState) {
 
-    // TODO:permissions stop persisting permissionsDescriptions and remove this line
-    const initState = { ...restoredState, permissionsRequests: [] }
+    const initState = Object.keys(restoredState)
+      .filter(k => {
+        return ![
+          'permissionsDescriptions',
+          'permissionsRequests',
+        ].includes(k)
+      })
+      .reduce((acc, k) => {
+        acc[k] = restoredState[k]
+        return acc
+      }, {})
 
     this.testProfile = {
       name: 'Dan Finlay',

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -149,7 +149,6 @@ class PluginsController extends EventEmitter {
     console.log('running add plugin with ', plugin)
     const { sourceCode, initialPermissions } = plugin
 
-
     const ethereumProvider = this.setupProvider(pluginName, async () => { return {name: pluginName } }, true)
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Accomplished by no longer restoring permissions descriptions, which was an old action item anyway.

Fixes #40 