### PR TITLE
Adds getTxById to restricted methods available to plugins

### DIFF
--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -27,6 +27,7 @@ const pluginRestrictedMethodDescriptions = {
   getApprovedAccounts: 'Get a list of all approved accounts',
   getFilteredTxList: 'Get a list of filtered transactions',
   getGasPrice: 'Estimates a good gas price at recent prices',
+  getTxById: 'Get full data of a transaction with a given metamask tx id',
   getState: 'Get a JSON representation of MetaMask data, including sensitive data. This is only for testing purposes and will NOT be included in production.',
   importAccountWithStrategy: 'Imports an account with the specified import strategy',
   isNonceTaken: 'Check if a given nonce is available for use',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -291,6 +291,7 @@ module.exports = class MetamaskController extends EventEmitter {
         updatePluginState: this.pluginsController.updatePluginState.bind(this.pluginController),
         getPluginState: this.pluginsController.getPluginState.bind(this.pluginController),
         onNewTx: this.txController.on.bind(this.txController, 'newUnapprovedTx'),
+        getTxById: this.txController.txStateManager.getTx.bind(this.txController.txStateManager),
       },
       getApi: this.getPluginsApi.bind(this),
       metamaskEventMethods: this.pluginsController.generateMetaMaskListenerMethodsMap(),
@@ -661,6 +662,7 @@ module.exports = class MetamaskController extends EventEmitter {
       getFilteredTxList: nodeify(txController.getFilteredTxList, txController),
       isNonceTaken: nodeify(txController.isNonceTaken, txController),
       estimateGas: nodeify(this.estimateGas, this),
+      getTxById: this.txController.txStateManager.getTx.bind(this.txController.txStateManager),
 
       // messageManager
       signMessage: nodeify(this.signMessage, this),


### PR DESCRIPTION
Adds a new capability for plugins to request: a method that will return a transactions full metamask data when passed that transaction's internal metamask id.

Usage of this method is demonstrated in the new plugin example added with https://github.com/MetaMask/mm-plugin/pull/27