### PR TITLE
feat: localize plugin provider to mitigate supply chain attacks

### DIFF
--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -304,7 +304,6 @@ class PluginsController extends EventEmitter {
     Object.assign(ethereumProvider, apisToProvide)
     try {
       const sessedPlugin = this.rootRealm.evaluate(sourceCode, {
-        wallet: ethereumProvider,
         console, // Adding console for now for logging purposes.
         BigInt,
         window: {
@@ -321,6 +320,7 @@ class PluginsController extends EventEmitter {
         WebSocket,
         Buffer,
         Date,
+        registerPlugin: initializer => initializer(ethereumProvider),
       })
       sessedPlugin()
     } catch (err) {


### PR DESCRIPTION
This pull request localizes plugin provider instances within plugins to mitigate the possibility of dependency supply chain attacks. This is done by exposing a new top-level `registerPlugin` API; this seemed like less of a hack than relying on internal (possibly changing) semantics of immutability within SES.

**Note:** Once this lands, the following updates should be made:

- [ ] Update [plugin examples](https://github.com/MetaMask/mm-plugin/tree/master/examples)
- [ ] Update [plugin skeleton](https://github.com/MetaMask/mm-plugin/blob/master/src/initTemplate.json)

Resolves https://github.com/MetaMask/metamask-plugin-beta/issues/53