### PR TITLE
Add identity api patch1

### DIFF
--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -141,7 +141,8 @@ class AccountsController extends EventEmitter {
 
   async signTransaction (ethTx, fromAddress, opts) {
     try {
-      return this.keyringController.signTransaction(ethTx, fromAddress, opts)
+      const signedTx = await this.keyringController.signTransaction(ethTx, fromAddress, opts)
+      return signedTx
     } catch (err) {
       const address = normalizeAddress(fromAddress)
       if (!this.pluginManagesAddress(address)) {
@@ -160,7 +161,8 @@ class AccountsController extends EventEmitter {
 
   async signMessage (msgParams) {
     try {
-      return this.keyringController.signMessage(msgParams)
+      const signedMessage = await this.keyringController.signMessage(msgParams)
+      return signedMessage
     } catch (err) {
       const address = normalizeAddress(msgParams.from)
       if (!this.pluginManagesAddress(address)) {
@@ -176,7 +178,8 @@ class AccountsController extends EventEmitter {
 
   async signPersonalMessage (msgParams) {
     try {
-      return this.keyringController.signPersonalMessage(msgParams)
+      const signedPersonalMessage = await this.keyringController.signPersonalMessage(msgParams)
+      return signedPersonalMessage
     } catch (err) {
       const address = normalizeAddress(msgParams.from)
       if (!this.pluginManagesAddress(address)) {

--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -99,7 +99,7 @@ class AccountsController extends EventEmitter {
       const accounts = pluginAccounts.filter((account) => {
         return account.fromDomain === domain
       })
-      .map(account => account.address)
+        .map(account => normalizeAddress(account.address))
 
       return {
         type: domain,
@@ -195,7 +195,7 @@ class AccountsController extends EventEmitter {
     try {
       return this.keyringController.exportAppKeyForAddress(account, origin)
     } catch (err) {
-      const address = normalizeAddress(msgParams.from)
+      const address = normalizeAddress(account)
       if (!this.pluginManagesAddress(address)) {
         throw new Error('No keyring or plugin found for the requested account.')
       }

--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -112,13 +112,18 @@ class AccountsController extends EventEmitter {
     return update
   }
 
-  getHandlerForAccount (address) {
+  _getUniquePluginAccountDomains (address) {
     const pluginAccounts = this.pluginAccounts.resources
     const accounts = pluginAccounts.filter(acct => normalizeAddress(acct.address) === address)
     const domains = accounts.map(acct => acct.fromDomain)
-    const uniques = domains.filter(onlyUnique)
+    const uniquePluginAccountDomains = domains.filter(onlyUnique)
+    return uniquePluginAccountDomains
+  }
 
-    if (uniques.length > 1) {
+  getHandlerForAccount (address) {
+    const uniquePluginAccountDomains = this._getUniquePluginAccountDomains(address)
+
+    if (uniquePluginAccountDomains.length > 1) {
       throw new Error(`Multiple plugins claiming ownership of account ${address}, please request from plugin directly.`)
     }
 
@@ -126,8 +131,8 @@ class AccountsController extends EventEmitter {
       throw new Error('No handlers exist to manage account.')
     }
 
-    const handler = this.pluginsController.accountMessageHandlers.get(uniques[0])
-    if (uniques.length === 0 || !handler) {
+    const handler = this.pluginsController.accountMessageHandlers.get(uniquePluginAccountDomains[0])
+    if (uniquePluginAccountDomains.length === 0 || !handler) {
       throw new Error(`No handler plugin for account ${address} found.`)
     }
 

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -413,10 +413,17 @@ class TransactionController extends EventEmitter {
     // sign tx
     const fromAddress = txParams.from
     const ethTx = new Transaction(txParams)
-    await this.signEthTx(ethTx, fromAddress)
+    const signedTx = await this.signEthTx(ethTx, fromAddress)
+    let rawTx
+    if (signedTx.serialize) {
+      rawTx = ethUtil.bufferToHex(signedTx.serialize())
+    } else if (signedTx === '0x' || (signedTx.slice(0, 2) === '0x' && signedTx.slice(2).match(/^[A-Fa-f0-9]+$/))) {
+      rawTx = signedTx
+    } else {
+      throw new Error('signedTx is not of correct type')
+    }
     // set state to signed
     this.txStateManager.setTxStatusSigned(txMeta.id)
-    const rawTx = ethUtil.bufferToHex(ethTx.serialize())
     return rawTx
   }
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1696,7 +1696,9 @@ module.exports = class MetamaskController extends EventEmitter {
    */
   async _onAccountControllerUpdate (state) {
     const {isUnlocked, accountrings} = state
-    const addresses = accountrings.reduce((acc, {accounts}) => acc.concat(accounts), [])
+    const addresses = accountrings
+      .reduce((acc, {accounts}) => acc.concat(accounts), [])
+      .map(addr => sigUtil.normalize(addr))
 
     if (!addresses.length) {
       return


### PR DESCRIPTION
This PR updates #63 so that it correctly supports the example in https://github.com/MetaMask/mm-plugin/pull/31

The following changes were made:
ec4bc84cf Ensure keyring controller continues to correctly update on state changes and account imports
7d015a55a Allow custom signEthTx method to return signed tx as a hex string in tx controller signTransaction method
fe9813ee8 Pass origin as first param to signing methods in accounts controller
c962e9c27 Fix error catching in signing methods of accounts controller
7e3e1fabe Extract determination of unique domains for a plugin from getHandlerForAccount to its own method
fd6d73518 Normalize addresses in account controller state, for consistency with keyring controller
fbe68d024 Update accounts controller remove method to properly clean up accounts in state on removal

Note that this PR has been updated from a previous version that included the addition of an api metamask native prompts. This has now all been moved to #86 