### PR TITLE
Fix 'Hide Token' button for custom assets in the token list

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -515,6 +515,9 @@ module.exports = class MetamaskController extends EventEmitter {
       completeOnboarding: nodeify(preferencesController.completeOnboarding, preferencesController),
       addKnownMethodData: nodeify(preferencesController.addKnownMethodData, preferencesController),
 
+      // AssetsController
+      removeAsset: nodeify(this.assetsController.removeAsset, this.assetsController),
+
       // BlacklistController
       whitelistPhishingDomain: this.whitelistPhishingDomain.bind(this),
 

--- a/ui/app/components/app/modals/hide-token-confirmation-modal.js
+++ b/ui/app/components/app/modals/hide-token-confirmation-modal.js
@@ -23,6 +23,12 @@ function mapDispatchToProps (dispatch) {
           dispatch(actions.hideModal())
         })
     },
+    hideAsset: (fromDomain, asset) => {
+      dispatch(actions.removeAsset(fromDomain, asset))
+        .then(() => {
+          dispatch(actions.hideModal())
+        })
+    },
   }
 }
 
@@ -41,8 +47,9 @@ module.exports = connect(mapStateToProps, mapDispatchToProps)(HideTokenConfirmat
 
 
 HideTokenConfirmationModal.prototype.render = function () {
-  const { token, network, hideToken, hideModal, assetImages } = this.props
-  const { symbol, address } = token
+  const { token, network, hideToken, hideModal, assetImages, hideAsset } = this.props
+
+  const { symbol, address, fromDomain } = token
   const image = assetImages[address]
 
   return h('div.hide-token-confirmation', {}, [
@@ -73,7 +80,7 @@ HideTokenConfirmationModal.prototype.render = function () {
           this.context.t('cancel'),
         ]),
         h('button.btn-secondary.hide-token-confirmation__button.btn--large', {
-          onClick: () => hideToken(address),
+          onClick: () => fromDomain ? hideAsset(fromDomain, token) : hideToken(address),
         }, [
           this.context.t('hide'),
         ]),

--- a/ui/app/components/app/token-cell.js
+++ b/ui/app/components/app/token-cell.js
@@ -142,7 +142,7 @@ TokenCell.prototype.render = function () {
 
       tokenMenuOpen && h(TokenMenuDropdown, {
         onClose: () => this.setState({ tokenMenuOpen: false }),
-        token: { symbol, address },
+        token: { symbol, address, fromDomain, identifier },
       }),
 
       /*

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -239,6 +239,7 @@ var actions = {
   addTokens,
   removeToken,
   updateTokens,
+  removeAsset,
   removeSuggestedTokens,
   addKnownMethodData,
   UPDATE_TOKENS: 'UPDATE_TOKENS',
@@ -1707,6 +1708,24 @@ function removeToken (address) {
         }
         dispatch(actions.updateTokens(tokens))
         resolve(tokens)
+      })
+    })
+  }
+}
+
+function removeAsset (fromDomain, asset) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    return new Promise((resolve, reject) => {
+      console.log('fromDomain, asset', fromDomain, asset)
+      background.removeAsset(fromDomain, asset, (err, removedAsset) => {
+        console.log('removedAsset', removedAsset)
+        dispatch(actions.hideLoadingIndication())
+        if (err) {
+          dispatch(actions.displayWarning(err.message))
+          return reject(err)
+        }
+        resolve(removedAsset)
       })
     })
   }


### PR DESCRIPTION
When custom assets are added to the token list, there is no way to remove them. This fixes this so that the "hide token" button works for custom assets as well as tokens.