### PR TITLE
Bring plugin provider to inpage parity

### DIFF
--- a/app/scripts/lib/duplex-socket.js
+++ b/app/scripts/lib/duplex-socket.js
@@ -1,0 +1,70 @@
+// From: https://stackoverflow.com/a/55136548/272576
+// Modified to our eslint and to support object-mode.
+const Duplex = require('stream').Duplex
+const assert = require('assert')
+
+// Define some unique property names.
+// The actual value doesn't matter,
+// so long as they're not used by Node.js for anything else.
+const kCallback = Symbol('Callback')
+const kOtherSide = Symbol('Other')
+
+// Define a function `DuplexSocket` whose prototype inherits from `Duplex`
+class DuplexSocket extends Duplex {
+  constructor (opts) {
+    // Let Node.js initialize everything it needs to
+    super(opts)
+    // Define two values we will be using
+    // kCallback saves a temporary reference to a function while
+    this[kCallback] = null
+    // kOtherSide will be the reference to the other side of the stream
+    this[kOtherSide] = null
+  }
+
+  _read () {
+    // This is called when this side receives a push() call
+    // If the other side set a callback for us to call,
+    // then first clear that reference
+    // (it might be immediately set to a new value again),
+    // then call the function.
+    const callback = this[kCallback]
+    if (callback) {
+      this[kCallback] = null
+      callback()
+    }
+  }
+
+  _write (chunk, _encoding, callback) {
+    // This is called when someone writes to the stream
+    // Ensure there's a reference to the other side before trying to call it
+    assert.notStrictEqual(this[kOtherSide], null)
+    // Ensure that the other-side callback is empty before setting it
+    // If push immediately calls _read, this should never be a problem
+    assert.strictEqual(this[kOtherSide][kCallback], null)
+    // Let Node.js know when _read has been called
+    this[kOtherSide][kCallback] = callback
+    // And finally, send the other side the data to be read
+    this[kOtherSide].push(chunk)
+  }
+
+  _final (callback) {
+    // Ask the other side to let us know it received our EOF request
+    this[kOtherSide].on('end', callback)
+    // And finally, pushing null signals the end of the stream
+    this[kOtherSide].push(null)
+  }
+}
+
+function makeDuplexPair () {
+  // Create two pairs of
+  const clientSide = new DuplexSocket({ objectMode: true })
+  const serverSide = new DuplexSocket({ objectMode: true })
+  // Set the other-side reference
+  clientSide[kOtherSide] = serverSide
+  serverSide[kOtherSide] = clientSide
+  // Both instances behave the same, so choice of name doesn't matter,
+  // So long as they're distinguishable.
+  return { clientSide, serverSide }
+}
+
+module.exports = makeDuplexPair

--- a/app/scripts/lib/select-chain-id.js
+++ b/app/scripts/lib/select-chain-id.js
@@ -15,6 +15,9 @@ const standardNetworkId = {
 }
 
 function selectChainId (metamaskState) {
+  if (!metamaskState || !metamaskState.provider || !metamaskState.provider.chaindId) {
+    return undefined
+  }
   const { network, provider: { chaindId } } = metamaskState
   return standardNetworkId[network] || `0x${parseInt(chaindId, 10).toString(16)}`
 }

--- a/app/scripts/lib/stream-utils.js
+++ b/app/scripts/lib/stream-utils.js
@@ -1,11 +1,13 @@
 const Through = require('through2')
 const ObjectMultiplex = require('obj-multiplex')
 const pump = require('pump')
+const makeDuplexPair = require('./duplex-socket')
 
 module.exports = {
   jsonParseStream: jsonParseStream,
   jsonStringifyStream: jsonStringifyStream,
   setupMultiplex: setupMultiplex,
+  makeDuplexPair,
 }
 
 /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -20,8 +20,8 @@ const createSubscriptionManager = require('eth-json-rpc-filters/subscriptionMana
 const createLoggerMiddleware = require('./lib/createLoggerMiddleware')
 const createOriginMiddleware = require('./lib/createOriginMiddleware')
 const providerAsMiddleware = require('eth-json-rpc-middleware/providerAsMiddleware')
-const providerFromEngine = require('eth-json-rpc-middleware/providerFromEngine')
-const {setupMultiplex} = require('./lib/stream-utils.js')
+const MetamaskInpageProvider = require('metamask-inpage-provider')
+const {setupMultiplex, makeDuplexPair} = require('./lib/stream-utils.js')
 const KeyringController = require('eth-keyring-controller')
 const NetworkController = require('./controllers/network')
 const PreferencesController = require('./controllers/preferences')
@@ -437,10 +437,11 @@ module.exports = class MetamaskController extends EventEmitter {
   getState () {
     const vault = this.keyringController.store.getState().vault
     const isInitialized = !!vault
+    const flatState = this.memStore ? this.memStore.getFlatState() : {}
 
     return {
       ...{ isInitialized },
-      ...this.memStore.getFlatState(),
+      ...flatState,
     }
   }
 
@@ -1483,7 +1484,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @param {string} originDomain - The domain requesting the stream, which
    * may trigger a blacklist reload.
    */
-  setupUntrustedCommunication (connectionStream, originDomain) {
+  setupUntrustedCommunication (connectionStream, originDomain, getSiteMetadata, isPlugin = false) {
     // Check if new connection is blacklisted
     if (this.phishingController.test(originDomain)) {
       log.debug('MetaMask - sending phishing warning for', originDomain)
@@ -1495,7 +1496,7 @@ module.exports = class MetamaskController extends EventEmitter {
     const mux = setupMultiplex(connectionStream)
 
     // messages between inpage and background
-    this.setupProviderConnection(mux.createStream('provider'), originDomain)
+    this.setupProviderConnection(mux.createStream('provider'), originDomain, getSiteMetadata, isPlugin)
     this.setupCapnodeConnection(mux.createStream('cap'), originDomain)
     this.setupPublicConfig(mux.createStream('publicConfig'))
   }
@@ -1571,8 +1572,8 @@ module.exports = class MetamaskController extends EventEmitter {
    * @param {*} outStream - The stream to provide over.
    * @param {string} origin - The URI of the requesting resource.
    */
-  setupProviderConnection (outStream, origin) {
-    const engine = this.setupProviderEngine(origin)
+  setupProviderConnection (outStream, origin, getSiteMetadata, isPlugin = false) {
+    const engine = this.setupProviderEngine(origin, getSiteMetadata, isPlugin)
 
     // setup connection
     const providerStream = createEngineStream({ engine })
@@ -1618,18 +1619,9 @@ module.exports = class MetamaskController extends EventEmitter {
   }
 
   setupProvider (origin, getSiteMetadata, isPlugin) {
-    const engine = this.setupProviderEngine(origin, getSiteMetadata, isPlugin)
-    const provider = providerFromEngine(engine)
-    provider.send = async (payload) => {
-      return new Promise((res, rej) => {
-        provider.sendAsync(payload, (err, response) => {
-          if (err) {
-            return rej(err)
-          }
-          res(response)
-        })
-      })
-    }
+    const { clientSide, serverSide } = makeDuplexPair()
+    this.setupUntrustedCommunication(serverSide, origin, getSiteMetadata, isPlugin)
+    const provider = new MetamaskInpageProvider(clientSide)
     return provider
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17948,7 +17948,6 @@ metamask-inpage-provider@MetaMask/metamask-inpage-provider#plugins:
   version "3.0.0"
   resolved "https://codeload.github.com/MetaMask/metamask-inpage-provider/tar.gz/0aca8453bbc82eb4f024f210bd00201e82a1f8cf"
   dependencies:
-    fast-deep-equal "^2.0.1"
     json-rpc-engine "^5.1.3"
     json-rpc-middleware-stream "^2.1.1"
     loglevel "^1.6.1"


### PR DESCRIPTION
Bringing the `inpage-provider` module into `metamask-controller` so it can be properly extended and provided to plugins.

Required using a `duplex-socket` technique. The hardest part of this was learning that `duplex-socket` is the node-streams-land word for "two duplex streams that are connected", which turns out is what we required to fit together the two duplex-stream-consuming sides of the connection: `metamask-inpage-provider` and `metamaskController.setupUntrustedCommunication(duplex)`.

Anyways, once that duplex piece is understood, the rest of the change is pretty simple. We are now using our production inpage provider module instead of the `jsonRpcEngine.providerFromEngine()` method, which lacks a few features and produces much more of a simple method-passing rpc provider (no events).