### PR TITLE
Change localhost manifest permission to include all ports

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -68,7 +68,7 @@
     "storage",
     "unlimitedStorage",
     "clipboardWrite",
-    "http://localhost:8545/",
+    "http://localhost/*",
     "https://*.infura.io/",
     "activeTab",
     "webRequest",


### PR DESCRIPTION
In `manifest.json:permissions`, `http://localhost:8545/` changed to `http://localhost/*` to prevent issues fetching plugins while developing in Firefox.

This probably indicates that we will have problems fetching plugins in production using Firefox, if using our existing setup.

Fixes https://github.com/MetaMask/metamask-snaps-beta/issues/108