### PR TITLE
Add plugin settings page

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -14,9 +14,6 @@
   "chartOnlyAvailableEth": {
     "message": "Chart only available on Ethereum networks."
   },
-  "confirmClear": {
-    "message": "Are you sure you want to remove all dapp/website permissions?"
-  },
   "connections": {
     "message": "Connections"
   },
@@ -41,14 +38,47 @@
   "contractInteraction": {
     "message": "Contract Interaction"
   },
-  "clearPermissionsSuccess": {
-    "message": "Permissions cleared successfully."
+  "plugins": {
+    "message": "Snaps"
+  },
+  "pluginsDescription": {
+    "message": "All currently installed plugins. Deselect Snaps and click \"Update Snaps\" to remove them."
+  },
+  "pluginsSettingsDescription": {
+    "message": "Manage Snaps"
+  },
+  "clearPlugins": {
+    "message": "Clear Snaps"
+  },
+  "clearPluginsDescription": {
+    "message": "Remove all Snaps and their associated permissions."
+  },
+  "confirmClearPlugins": {
+    "message": "Are you sure you want to remove all Snaps and their associated permissions?"
+  },
+  "clearPluginsSuccess": {
+    "message": "Snaps cleared successfully."
+  },
+  "pluginsSettings": {
+    "message": "Manage Snaps"
+  },
+  "pluginsEmpty": {
+    "message": "No Snaps found."
+  },
+  "updatePlugins": {
+    "message": "Update Snaps"
   },
   "permissionsSettings": {
     "message": "Manage Permissions"
   },
   "permissionsDescription": {
     "message": "All currently granted permissions, by dapp/website. Deselect permissions and click \"Update Permissions\" to remove them."
+  },
+  "permissions": {
+    "message": "Permissions"
+  },
+  "permissionsSettingsDescription": {
+    "message": "Manage dapp/website permissions"
   },
   "permissionsEmpty": {
     "message": "No permissions found."
@@ -58,6 +88,12 @@
   },
   "clearPermissionsDescription": {
     "message": "Clear permissions so that all dapps/websites must request access again."
+  },
+  "confirmClearPermissions": {
+    "message": "Are you sure you want to remove all dapp/website permissions?"
+  },
+  "clearPermissionsSuccess": {
+    "message": "Permissions cleared successfully."
   },
   "updatePermissions": {
     "message": "Update Permissions"
@@ -77,6 +113,9 @@
   "clearPermissionsActivityDescription": {
     "message": "Clear the permissions activity log."
   },
+  "confirmClearPermissionsActivity": {
+    "message": "Are you sure you want to clear the permissions activity log?"
+  },
   "permissionsHistorySettings": {
     "message": "Permissions History"
   },
@@ -91,6 +130,9 @@
   },
   "clearPermissionsHistoryDescription": {
     "message": "Clear the permissions history."
+  },
+  "confirmClearPermissionsHistory": {
+    "message": "Are you sure you want to clear the permissions history?"
   },
   "reject": {
     "message": "Reject"
@@ -965,12 +1007,6 @@
   },
   "pending": {
     "message": "pending"
-  },
-  "permissions": {
-    "message": "Permissions"
-  },
-  "permissionsSettingsDescription": {
-    "message": "Manage dapp/website permissions."
   },
   "personalAddressDetected": {
     "message": "Personal address detected. Input the token contract address."

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -84,24 +84,6 @@ function getExternalRestrictedMethods (permissionsController) {
       },
     },
 
-    'readYourProfile': {
-      description: 'Read from your profile',
-      method: (_req, res, _next, end) => {
-        res.result = permissionsController.testProfile
-        end()
-      },
-    },
-
-    'writeToYourProfile': {
-      description: 'Write to your profile.',
-      method: (req, res, _next, end) => {
-        const [ key, value ] = req.params
-        permissionsController.testProfile[key] = value
-        res.result = permissionsController.testProfile
-        return end()
-      },
-    },
-
     'wallet_manageAssets': {
       description: 'Display custom assets in your wallet.',
       method: (req, res, _next, end, engine) => {

--- a/ui/app/components/app/modals/clear-permissions-activity/clear-permissions-activity.component.js
+++ b/ui/app/components/app/modals/clear-permissions-activity/clear-permissions-activity.component.js
@@ -31,7 +31,7 @@ export default class ClearPermissionsActivity extends PureComponent {
       >
         <ModalContent
           title={t('clearPermissionsActivity')}
-          description={t('confirmClear')}
+          description={t('confirmClearPermissionsActivity')}
         />
       </Modal>
     )

--- a/ui/app/components/app/modals/clear-permissions/clear-permissions.component.js
+++ b/ui/app/components/app/modals/clear-permissions/clear-permissions.component.js
@@ -31,7 +31,7 @@ export default class ClearPermissions extends PureComponent {
       >
         <ModalContent
           title={t('clearPermissions')}
-          description={t('confirmClear')}
+          description={t('confirmClearPermissions')}
         />
       </Modal>
     )

--- a/ui/app/components/app/modals/clear-plugins/clear-plugins.component.js
+++ b/ui/app/components/app/modals/clear-plugins/clear-plugins.component.js
@@ -2,10 +2,10 @@ import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import Modal, { ModalContent } from '../../modal'
 
-export default class ClearPermissionsHistory extends PureComponent {
+export default class ClearPlugins extends PureComponent {
   static propTypes = {
     hideModal: PropTypes.func.isRequired,
-    clearPermissionsHistory: PropTypes.func.isRequired,
+    clearPlugins: PropTypes.func.isRequired,
   }
 
   static contextTypes = {
@@ -13,8 +13,8 @@ export default class ClearPermissionsHistory extends PureComponent {
   }
 
   handleClear = () => {
-    const { clearPermissionsHistory, hideModal } = this.props
-    clearPermissionsHistory()
+    const { clearPlugins, hideModal } = this.props
+    clearPlugins()
     hideModal()
   }
 
@@ -30,8 +30,8 @@ export default class ClearPermissionsHistory extends PureComponent {
         submitType="secondary"
       >
         <ModalContent
-          title={t('clearPermissionsHistory')}
-          description={t('confirmClearPermissionsHistory')}
+          title={t('clearPlugins')}
+          description={t('confirmClearPlugins')}
         />
       </Modal>
     )

--- a/ui/app/components/app/modals/clear-plugins/clear-plugins.container.js
+++ b/ui/app/components/app/modals/clear-plugins/clear-plugins.container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux'
+import { compose } from 'recompose'
+import withModalProps from '../../../../helpers/higher-order-components/with-modal-props'
+import ClearPluginsComponent from './clear-plugins.component'
+import { clearPlugins } from '../../../../store/actions'
+
+const mapDispatchToProps = dispatch => {
+  return {
+    clearPlugins: () => dispatch(clearPlugins()),
+  }
+}
+
+export default compose(
+  withModalProps,
+  connect(null, mapDispatchToProps)
+)(ClearPluginsComponent)

--- a/ui/app/components/app/modals/clear-plugins/index.js
+++ b/ui/app/components/app/modals/clear-plugins/index.js
@@ -1,0 +1,1 @@
+export { default } from './clear-plugins.container'

--- a/ui/app/components/app/modals/modal.js
+++ b/ui/app/components/app/modals/modal.js
@@ -27,6 +27,7 @@ import RejectTransactions from './reject-transactions'
 import ClearPermissions from './clear-permissions'
 import ClearPermissionsActivity from './clear-permissions-activity'
 import ClearPermissionsHistory from './clear-permissions-history'
+import ClearPlugins from './clear-plugins'
 import ConfirmCustomizeGasModal from '../gas-customization/gas-modal-page-container'
 import ConfirmDeleteNetwork from './confirm-delete-network'
 import AddToAddressBookModal from './add-to-addressbook-modal'
@@ -200,6 +201,19 @@ const MODALS = {
 
   CLEAR_PERMISSIONS_HISTORY: {
     contents: h(ClearPermissionsHistory),
+    mobileModalStyle: {
+      ...modalContainerMobileStyle,
+    },
+    laptopModalStyle: {
+      ...modalContainerLaptopStyle,
+    },
+    contentStyle: {
+      borderRadius: '8px',
+    },
+  },
+
+  CLEAR_PLUGINS: {
+    contents: h(ClearPlugins),
     mobileModalStyle: {
       ...modalContainerMobileStyle,
     },

--- a/ui/app/helpers/constants/routes.js
+++ b/ui/app/helpers/constants/routes.js
@@ -6,6 +6,7 @@ const GENERAL_ROUTE = '/settings/general'
 const ADVANCED_ROUTE = '/settings/advanced'
 const SECURITY_ROUTE = '/settings/security'
 const PERMISSIONS_ROUTE = '/settings/permissions'
+const PLUGINS_ROUTE = '/settings/plugins'
 const ABOUT_US_ROUTE = '/settings/about-us'
 const NETWORKS_ROUTE = '/settings/networks'
 const CONTACT_LIST_ROUTE = '/settings/contact-list'
@@ -83,6 +84,7 @@ module.exports = {
   ADVANCED_ROUTE,
   SECURITY_ROUTE,
   PERMISSIONS_ROUTE,
+  PLUGINS_ROUTE,
   GENERAL_ROUTE,
   ABOUT_US_ROUTE,
   CONTACT_LIST_ROUTE,

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -49,10 +49,11 @@ export default class Home extends PureComponent {
     threeBoxLastUpdated: PropTypes.string,
     threeBoxFeatureFlagIsTrue: PropTypes.bool,
     permissionsRequests: PropTypes.array,
-    deletePlugin: PropTypes.func,
-    clearPluginState: PropTypes.func,
-    clearPermissions: PropTypes.func,
-    clearPermissionsHistory: PropTypes.func,
+    removePlugin: PropTypes.func,
+    clearPlugins: PropTypes.func,
+    clearAllPermissionsData: PropTypes.func,
+    hasPermissionsData: PropTypes.bool,
+    hasPlugins: PropTypes.bool,
   }
 
   state = {
@@ -109,6 +110,8 @@ export default class Home extends PureComponent {
       threeBoxLastUpdated,
       threeBoxFeatureFlagIsTrue,
       permissionsRequests,
+      hasPermissionsData,
+      hasPlugins
     } = this.props
 
     if (forgottenPassword) {
@@ -171,12 +174,24 @@ export default class Home extends PureComponent {
                     },
                   ]}/>
                 <div>
-                  <Button onClick={() => this.props.clearPluginState()} >{ 'Delete All Plugins' }</Button>
-                  <Button onClick={() => {
-                    this.props.clearPermissions()
-                    this.props.clearPermissionsHistory()
-                    alert('Permissions state cleared.')
-                  }} >{ 'Delete All Permissions' }</Button>
+
+                  <Button
+                    onClick={() => {
+                      this.props.clearPlugins()
+                    }}
+                    disabled={!hasPlugins}
+                  >
+                    { 'Delete All Plugins' }
+                  </Button>
+
+                  <Button
+                    onClick={() => {
+                      this.props.clearAllPermissionsData()
+                    }}
+                    disabled={!hasPermissionsData}
+                  >
+                    { 'Delete All Permissions' }
+                  </Button>
                 </div>
               </TransactionView>
             )

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -111,7 +111,7 @@ export default class Home extends PureComponent {
       threeBoxFeatureFlagIsTrue,
       permissionsRequests,
       hasPermissionsData,
-      hasPlugins
+      hasPlugins,
     } = this.props
 
     if (forgottenPassword) {

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -45,8 +45,8 @@ const mapStateToProps = state => {
     Object.keys(getAllPermissions(state)).length > 0 ||
     Object.keys(getPermissionsHistory(state)).length > 0 ||
     Object.keys(getPermissionsLog(state)).length > 0
-  ) 
-  const hasPlugins = Object.keys(getAllPlugins(state)).length > 0 
+  )
+  const hasPlugins = Object.keys(getAllPlugins(state)).length > 0
 
   return {
     forgottenPassword,
@@ -63,7 +63,7 @@ const mapStateToProps = state => {
     permissionsRequests,
     // TODO:plugins:prod remove
     hasPermissionsData,
-    hasPlugins
+    hasPlugins,
   }
 }
 

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -3,16 +3,21 @@ import { compose } from 'recompose'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import { unconfirmedTransactionsCountSelector } from '../../selectors/confirm-transaction'
-import { getCurrentEthBalance } from '../../selectors/selectors'
+import {
+  getCurrentEthBalance,
+  getAllPermissions,
+  getAllPlugins,
+  getPermissionsHistory,
+  getPermissionsLog,
+} from '../../selectors/selectors'
 import {
   restoreFromThreeBox,
   turnThreeBoxSyncingOn,
   getThreeBoxLastUpdated,
   setRestoredFromThreeBoxToFalse,
-  deletePlugin,
-  clearPluginState,
-  clearPermissions,
-  clearPermissionsHistory,
+  removePlugin,
+  clearPlugins,
+  clearAllPermissionsData,
 } from '../../store/actions'
 import { setThreeBoxLastUpdated } from '../../ducks/app/app'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
@@ -35,6 +40,14 @@ const mapStateToProps = state => {
 
   const isPopup = getEnvironmentType(window.location.href) === ENVIRONMENT_TYPE_POPUP
 
+  // TODO:plugins:prod remove
+  const hasPermissionsData = (
+    Object.keys(getAllPermissions(state)).length > 0 ||
+    Object.keys(getPermissionsHistory(state)).length > 0 ||
+    Object.keys(getPermissionsLog(state)).length > 0
+  ) 
+  const hasPlugins = Object.keys(getAllPlugins(state)).length > 0 
+
   return {
     forgottenPassword,
     suggestedTokens,
@@ -48,6 +61,9 @@ const mapStateToProps = state => {
     threeBoxLastUpdated,
     threeBoxFeatureFlagIsTrue: featureFlags.threeBox,
     permissionsRequests,
+    // TODO:plugins:prod remove
+    hasPermissionsData,
+    hasPlugins
   }
 }
 
@@ -66,10 +82,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   restoreFromThreeBox: (address) => dispatch(restoreFromThreeBox(address)),
   setRestoredFromThreeBoxToFalse: () => dispatch(setRestoredFromThreeBoxToFalse()),
-  deletePlugin: (pluginName) => dispatch(deletePlugin(pluginName)),
-  clearPluginState: () => dispatch(clearPluginState()),
-  clearPermissions: () => dispatch(clearPermissions()),
-  clearPermissionsHistory: () => dispatch(clearPermissionsHistory()),
+  removePlugin: (pluginName) => dispatch(removePlugin(pluginName)),
+  clearPlugins: () => dispatch(clearPlugins()),
+  clearAllPermissionsData: () => dispatch(clearAllPermissionsData()),
 })
 
 export default compose(

--- a/ui/app/pages/settings/permissions-tab/permissions-list/permissions-list.component.js
+++ b/ui/app/pages/settings/permissions-tab/permissions-list/permissions-list.component.js
@@ -198,6 +198,10 @@ export default class PermissionsList extends Component {
   }
 
   renderPermissionsListItem (permission, description) {
+
+    // state may lag behind props slightly
+    if (!this.state.permissions[permission.id]) return null
+
     return (
       <li key={permission.id} className="settings-page__content-list-item">
         <input

--- a/ui/app/pages/settings/plugins-tab/index.js
+++ b/ui/app/pages/settings/plugins-tab/index.js
@@ -1,0 +1,1 @@
+export { default } from './plugins-tab.container'

--- a/ui/app/pages/settings/plugins-tab/plugins-list/index.js
+++ b/ui/app/pages/settings/plugins-tab/plugins-list/index.js
@@ -1,0 +1,165 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import deepEqual from 'fast-deep-equal'
+import Button from '../../../../components/ui/button'
+
+export default class PluginsList extends Component {
+
+  static propTypes = {
+    plugins: PropTypes.object.isRequired,
+    removePlugins: PropTypes.func.isRequired,
+  }
+
+  static contextTypes = {
+    t: PropTypes.func,
+  }
+
+  constructor (props) {
+    super(props)
+    this.state = {
+      plugins: {
+        ...this.getPluginsState(props),
+        // [pluginName]: {
+        //   selected: boolean,
+        // },
+      },
+    }
+  }
+
+  componentDidUpdate () {
+    const newPluginState = this.getPluginsState(this.props)
+    // if plugins have been added or removed, reset state
+    // TODO:review is this unnecessary given React's state management?
+    // Like, will React not re-render anyway if state isn't different?
+    if (!deepEqual(
+      Object.keys(this.state.plugins), Object.keys(newPluginState))
+    ) {
+      this.setState({ plugins: newPluginState })
+    }
+  }
+
+  getPluginsState (props) {
+    const { plugins } = props
+    return Object.keys(plugins).reduce((acc, pluginName) => {
+      acc[pluginName] = {
+        selected: true,
+      }
+      return acc
+    }, {})
+  }
+
+  // think of this as creating an event handling function
+  // bound to the given plugin id
+  onPluginToggle = (id) => () => {
+    const perm = { ...this.state.plugins[id] }
+    perm.selected = !perm.selected
+    this.setState({
+      plugins: {
+        ...this.state.plugins,
+        [id]: perm,
+      },
+    })
+  }
+
+  updatePlugins () {
+    this.props.removePlugins(
+      Object.keys(this.state.plugins)
+        .filter(pluginName => !this.state.plugins[pluginName].selected)
+    )
+  }
+
+  renderPluginsList () {
+    const { plugins } = this.props
+    return (
+      <ul>
+        {
+          Object.keys(plugins).sort().map(pluginName => {
+
+            if (
+              Object.keys(plugins).length === 0 ||
+              !this.state.plugins[pluginName] // state may lag behind props slightly
+            ) return null
+
+            // TODO: these elements look like trash and their CSS is placeholder only
+            return (
+              <li key={pluginName}>
+                <details className="settings-page__content-list-details">
+                  <summary>
+                    <input
+                      type="checkbox"
+                      checked={this.state.plugins[pluginName].selected}
+                      onChange={this.onPluginToggle(pluginName)}
+                      className="settings-page__content-list-checkbox"
+                    />
+                    {
+                      <i className="settings-page__content-list-indenticon--default">
+                        {pluginName}
+                      </i>
+                    }
+                    {pluginName}
+                    <i className="caret"></i>
+                  </summary>
+                  <ul>
+                    {
+                      this.renderPluginsListItem(pluginName, plugins[pluginName])
+                    }
+                  </ul>
+                </details>
+              </li>
+            )
+          })
+        }
+      </ul>
+    )
+  }
+
+  renderPluginsListItem (pluginName, pluginData) {
+    return Object.keys(pluginData).map(key => {
+      if (key !== 'sourceCode') {
+        return (
+          <li key={`${pluginName}:${key}`} className="settings-page__content-list-item">
+            {`${key}: ${JSON.stringify(pluginData[key])}`}
+          </li>
+        )
+      }
+    })
+  }
+
+  render () {
+    const { t } = this.context
+    const hasPlugins = Object.keys(this.props.plugins).length > 0
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>{ t('pluginsSettings') }</span>
+          <span className="settings-page__content-description">
+            { t('pluginsDescription') }
+          </span>
+        </div>
+        <div className="settings-page__content-item">
+          {
+            hasPlugins
+              ? this.renderPluginsList()
+              : t('pluginsEmpty')
+          }
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <Button
+              type="warning"
+              large
+              className="settings-tab__button--orange"
+              disabled={!hasPlugins}
+              onClick={event => {
+                event.preventDefault()
+                this.updatePlugins()
+              }}
+            >
+              { t('updatePlugins') }
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/ui/app/pages/settings/plugins-tab/plugins-tab.component.js
+++ b/ui/app/pages/settings/plugins-tab/plugins-tab.component.js
@@ -1,0 +1,70 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Button from '../../../components/ui/button'
+import PluginsList from './plugins-list'
+
+export default class PluginsTab extends Component {
+
+  static propTypes = {
+    warning: PropTypes.string,
+    plugins: PropTypes.object.isRequired,
+    removePlugins: PropTypes.func.isRequired,
+    showClearPluginsModal: PropTypes.func.isRequired,
+  }
+
+  static contextTypes = {
+    t: PropTypes.func,
+  }
+
+  renderClearButton (messageKey, clickHandler, isDisabled) {
+    const { t } = this.context
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>{ t(messageKey) }</span>
+          <span className="settings-page__content-description">
+            { t(`${messageKey}Description`) }
+          </span>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <Button
+              type="warning"
+              large
+              className="settings-tab__button--orange"
+              disabled={isDisabled}
+              onClick={event => {
+                event.preventDefault()
+                clickHandler()
+              }}
+            >
+              { t(messageKey) }
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  render () {
+    const { warning } = this.props
+    const hasPlugins = Object.keys(this.props.plugins).length > 0
+
+    return (
+      <div className="settings-page__body">
+        { warning && <div className="settings-tab__error">{ warning }</div> }
+        <PluginsList
+          plugins={this.props.plugins}
+          removePlugins={this.props.removePlugins}
+        />
+        {
+          this.renderClearButton(
+            'clearPlugins',
+            this.props.showClearPluginsModal,
+            !hasPlugins
+          )
+        }
+      </div>
+    )
+  }
+}

--- a/ui/app/pages/settings/plugins-tab/plugins-tab.container.js
+++ b/ui/app/pages/settings/plugins-tab/plugins-tab.container.js
@@ -1,0 +1,36 @@
+import PluginsTab from './plugins-tab.component'
+import { compose } from 'recompose'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+import {
+  showModal,
+  removePlugins,
+} from '../../../store/actions'
+import {
+  getAllPlugins,
+} from '../../../selectors/selectors'
+
+const mapStateToProps = state => {
+  const { appState: { warning } } = state
+
+  return {
+    warning,
+    plugins: getAllPlugins(state),
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+  return {
+    showClearPluginsModal: () => dispatch(
+      showModal({ name: 'CLEAR_PLUGINS' })
+    ),
+    removePlugins: (pluginNames) => dispatch(
+      removePlugins(pluginNames)
+    ),
+  }
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps, mapDispatchToProps)
+)(PluginsTab)

--- a/ui/app/pages/settings/settings.component.js
+++ b/ui/app/pages/settings/settings.component.js
@@ -10,14 +10,17 @@ import InfoTab from './info-tab'
 import SecurityTab from './security-tab'
 import ContactListTab from './contact-list-tab'
 import PermissionsTab from './permissions-tab'
+import PluginsTab from './plugins-tab'
 import {
   DEFAULT_ROUTE,
   ADVANCED_ROUTE,
   SECURITY_ROUTE,
   GENERAL_ROUTE,
   ABOUT_US_ROUTE,
-  SETTINGS_ROUTE,
   NETWORKS_ROUTE,
+  PERMISSIONS_ROUTE,
+  PLUGINS_ROUTE,
+  SETTINGS_ROUTE,
   CONTACT_LIST_ROUTE,
   CONTACT_ADD_ROUTE,
   CONTACT_EDIT_ROUTE,
@@ -25,7 +28,6 @@ import {
   CONTACT_MY_ACCOUNTS_ROUTE,
   CONTACT_MY_ACCOUNTS_VIEW_ROUTE,
   CONTACT_MY_ACCOUNTS_EDIT_ROUTE,
-  PERMISSIONS_ROUTE,
 } from '../../helpers/constants/routes'
 
 class SettingsPage extends PureComponent {
@@ -158,6 +160,7 @@ class SettingsPage extends PureComponent {
           { content: t('contacts'), description: t('contactsSettingsDescription'), key: CONTACT_LIST_ROUTE },
           { content: t('securityAndPrivacy'), description: t('securitySettingsDescription'), key: SECURITY_ROUTE },
           { content: t('permissions'), description: t('permissionsSettingsDescription'), key: PERMISSIONS_ROUTE },
+          { content: t('plugins'), description: t('pluginsSettingsDescription'), key: PLUGINS_ROUTE },
           { content: t('networks'), description: t('networkSettingsDescription'), key: NETWORKS_ROUTE },
           { content: t('about'), description: t('aboutSettingsDescription'), key: ABOUT_US_ROUTE },
         ]}
@@ -239,6 +242,11 @@ class SettingsPage extends PureComponent {
           exact
           path={PERMISSIONS_ROUTE}
           component={PermissionsTab}
+        />
+        <Route
+          exact
+          path={PLUGINS_ROUTE}
+          component={PluginsTab}
         />
         <Route
           component={SettingsTab}

--- a/ui/app/pages/settings/settings.container.js
+++ b/ui/app/pages/settings/settings.container.js
@@ -8,11 +8,13 @@ import { ENVIRONMENT_TYPE_POPUP } from '../../../../app/scripts/lib/enums'
 import { getEnvironmentType } from '../../../../app/scripts/lib/util'
 
 import {
-  ADVANCED_ROUTE,
-  SECURITY_ROUTE,
-  GENERAL_ROUTE,
   ABOUT_US_ROUTE,
+  ADVANCED_ROUTE,
+  GENERAL_ROUTE,
   SETTINGS_ROUTE,
+  SECURITY_ROUTE,
+  PERMISSIONS_ROUTE,
+  PLUGINS_ROUTE,
   CONTACT_LIST_ROUTE,
   CONTACT_ADD_ROUTE,
   CONTACT_EDIT_ROUTE,
@@ -26,6 +28,8 @@ const ROUTES_TO_I18N_KEYS = {
   [GENERAL_ROUTE]: 'general',
   [ADVANCED_ROUTE]: 'advanced',
   [SECURITY_ROUTE]: 'securityAndPrivacy',
+  [PERMISSIONS_ROUTE]: 'permissions',
+  [PLUGINS_ROUTE]: 'plugins',
   [ABOUT_US_ROUTE]: 'about',
   [CONTACT_LIST_ROUTE]: 'contacts',
   [CONTACT_ADD_ROUTE]: 'newContact',

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -357,23 +357,23 @@ function getAllPlugins (state) {
 }
 
 function getPermissionsDescriptions (state) {
-  return state.metamask.permissionsDescriptions
+  return state.metamask.permissionsDescriptions || {} 
 }
 
 function getPermissionsRequests (state) {
-  return state.metamask.permissionsRequests
+  return state.metamask.permissionsRequests || []
 }
 
 function getPermissionsHistory (state) {
-  return state.metamask.permissionsHistory
+  return state.metamask.permissionsHistory || {}
 }
 
 function getPermissionsLog (state) {
-  return state.metamask.permissionsLog
+  return state.metamask.permissionsLog || {}
 }
 
 function getSiteMetadata (state) {
-  return state.metamask.siteMetadata
+  return state.metamask.siteMetadata || {}
 }
 
 function getActiveTab (state) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -357,7 +357,7 @@ function getAllPlugins (state) {
 }
 
 function getPermissionsDescriptions (state) {
-  return state.metamask.permissionsDescriptions || {} 
+  return state.metamask.permissionsDescriptions || {}
 }
 
 function getPermissionsRequests (state) {

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -53,6 +53,7 @@ const selectors = {
   getNumberOfTokens,
   isEthereumNetwork,
   getAllPermissions,
+  getAllPlugins,
   getPermissionsRequests,
   getPermissionsDescriptions,
   getPermissionsHistory,
@@ -349,6 +350,10 @@ function getAdvancedInlineGasShown (state) {
 
 function getAllPermissions (state) {
   return state.metamask.domains || {}
+}
+
+function getAllPlugins (state) {
+  return state.metamask.plugins || {}
 }
 
 function getPermissionsDescriptions (state) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -347,12 +347,14 @@ var actions = {
 
   // Permissions
   approvePermissionsRequest,
-  clearPermissions,
-  clearPermissionsHistory,
-  clearPermissionsLog,
   rejectPermissionsRequest,
   removePermissionsFor,
   selectApprovedAccount,
+  // clearing permission state
+  clearPermissions, // remove permissions only
+  clearPermissionsHistory,
+  clearPermissionsLog,
+  clearAllPermissionsData, // remove all of the above
 
   setFirstTimeFlowType,
   SET_FIRST_TIME_FLOW_TYPE: 'SET_FIRST_TIME_FLOW_TYPE',
@@ -390,8 +392,9 @@ var actions = {
   setRestoredFromThreeBoxToFalse,
   turnThreeBoxSyncingOn,
 
-  deletePlugin,
-  clearPluginState,
+  removePlugin,
+  removePlugins,
+  clearPlugins,
 }
 
 module.exports = actions
@@ -2715,6 +2718,17 @@ function removePermissionsFor (domains) {
 /**
  * Clears all permissions for all domains.
  */
+function clearAllPermissionsData () {
+  return () => {
+    background.clearPermissions()
+    background.clearPermissionsHistory()
+    background.clearPermissionsLog()
+  }
+}
+
+/**
+ * Clears all permissions for all domains.
+ */
 function clearPermissions () {
   return () => {
     background.clearPermissions()
@@ -2989,18 +3003,23 @@ function setThreeBoxSyncingPermission (threeBoxSyncingAllowed) {
   }
 }
 
-
-function deletePlugin (pluginName) {
+function removePlugin (pluginName) {
   return () => {
-    background.deletePlugin(pluginName)
+    background.removePlugin(pluginName)
   }
 }
 
-function clearPluginState () {
+function removePlugins (pluginNames) {
+  return () => {
+    background.removePlugins(pluginNames)
+  }
+}
+
+function clearPlugins () {
   return () => {
     background.clearPluginState()
   }
 }
 
-window.deletePlugin = deletePlugin
+window.deletePlugin = removePlugin
 


### PR DESCRIPTION
- adds basic plugin settings page
  - see which plugins are listed
  - see their associated data in a mostly readable format
  - remove specific plugins, or all of them
- when plugins are removed, their permissions are now also removed
  - any dapp permissions to interact with the plugin remain unaffected _(should they?)_
- improved plugin teardown on removal (listener removal etc.)
- misc
  - I had to mess with the controller init order, but this should be considered beyond the scope of this PR, as it will be addressed in the larger plugin installation flow PR at some other date

Fixes #50 