### PR TITLE
Ethers account and token tracking

### DIFF
--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -14,7 +14,6 @@ const pify = require('pify')
 const SINGLE_CALL_BALANCES_ABI = require('single-call-balance-checker-abi')
 const ethers = require('ethers')
 
-const { bnToHex } = require('./util')
 const { MAINNET_CODE, RINKEBY_CODE, ROPSTEN_CODE, KOVAN_CODE } = require('../controllers/network/enums')
 const { SINGLE_CALL_BALANCES_ADDRESS, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN, SINGLE_CALL_BALANCES_ADDRESS_KOVAN } = require('../controllers/network/contract-addresses')
 
@@ -231,13 +230,12 @@ class AccountTracker {
   async _updateAccountsViaBalanceChecker (addresses, deployedContractAddress) {
     const accounts = this.store.getState().accounts
     const ethContract = new ethers.Contract(deployedContractAddress, SINGLE_CALL_BALANCES_ABI, this.ethersProvider)
-    const ethBalance = ['0x0']
+    const ethBalance = [ethers.constants.AddressZero]
 
     try {
-      await ethContract.balances(addresses, ethBalance)
+      const result = await ethContract.balances(addresses, ethBalance)
       addresses.forEach((address, index) => {
-        const balance = bnToHex(result[index])
-        accounts[address] = { address, balance }
+        accounts[address] = { address, balance: result[index].toHexString() }
       })
     } catch (error) {
       log.warn(`MetaMask - Account Tracker single call balance fetch failed`, error)

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -11,12 +11,12 @@ const EthQuery = require('eth-query')
 const ObservableStore = require('obs-store')
 const log = require('loglevel')
 const pify = require('pify')
-const Web3 = require('web3')
-// const SINGLE_CALL_BALANCES_ABI = require('single-call-balance-checker-abi')
+const SINGLE_CALL_BALANCES_ABI = require('single-call-balance-checker-abi')
+const ethers = require('ethers')
 
-// const { bnToHex } = require('./util')
-// const { MAINNET_CODE, RINKEBY_CODE, ROPSTEN_CODE, KOVAN_CODE } = require('../controllers/network/enums')
-// const { SINGLE_CALL_BALANCES_ADDRESS, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN, SINGLE_CALL_BALANCES_ADDRESS_KOVAN } = require('../controllers/network/contract-addresses')
+const { bnToHex } = require('./util')
+const { MAINNET_CODE, RINKEBY_CODE, ROPSTEN_CODE, KOVAN_CODE } = require('../controllers/network/enums')
+const { SINGLE_CALL_BALANCES_ADDRESS, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN, SINGLE_CALL_BALANCES_ADDRESS_KOVAN } = require('../controllers/network/contract-addresses')
 
 
 class AccountTracker {
@@ -58,7 +58,7 @@ class AccountTracker {
     this._updateForBlock = this._updateForBlock.bind(this)
     this.network = opts.network
 
-    this.web3 = new Web3(this._provider)
+    this.ethersProvider = new ethers.providers.Web3Provider(this._provider)
   }
 
   start () {
@@ -181,24 +181,22 @@ class AccountTracker {
     const addresses = Object.keys(accounts)
     const currentNetwork = parseInt(this.network.getNetworkState())
 
-    // TODO:plugins re-implement _updateAccountsViaBalanceChecker using ethers
-    // and a modern balance checker at some point in the future
     switch (currentNetwork) {
-      // case MAINNET_CODE:
-      //   await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS)
-      //   break
+      case MAINNET_CODE:
+        await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS)
+        break
 
-      // case RINKEBY_CODE:
-      //   await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY)
-      //   break
+      case RINKEBY_CODE:
+        await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_RINKEBY)
+        break
 
-      // case ROPSTEN_CODE:
-      //   await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN)
-      //   break
+      case ROPSTEN_CODE:
+        await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN)
+        break
 
-      // case KOVAN_CODE:
-      //   await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_KOVAN)
-      //   break
+      case KOVAN_CODE:
+        await this._updateAccountsViaBalanceChecker(addresses, SINGLE_CALL_BALANCES_ADDRESS_KOVAN)
+        break
 
       default:
         await Promise.all(addresses.map(this._updateAccount.bind(this)))
@@ -225,29 +223,29 @@ class AccountTracker {
     this.store.updateState({ accounts })
   }
 
-  // /**
-  //  * Updates current address balances from balanceChecker deployed contract instance
-  //  * @param {*} addresses
-  //  * @param {*} deployedContractAddress
-  //  */
-  // async _updateAccountsViaBalanceChecker (addresses, deployedContractAddress) {
-  //   const accounts = this.store.getState().accounts
-  //   this.web3.setProvider(this._provider)
-  //   const ethContract = new this.web3.eth.Contract(SINGLE_CALL_BALANCES_ABI, deployedContractAddress)
-  //   const ethBalance = ['0x0']
+  /**
+   * Updates current address balances from balanceChecker deployed contract instance
+   * @param {*} addresses
+   * @param {*} deployedContractAddress
+   */
+  async _updateAccountsViaBalanceChecker (addresses, deployedContractAddress) {
+    const accounts = this.store.getState().accounts
+    const ethContract = new ethers.Contract(deployedContractAddress, SINGLE_CALL_BALANCES_ABI, this.ethersProvider)
+    const ethBalance = ['0x0']
 
-  //   ethContract.methods.balances(addresses, ethBalance).call(null, (error, result) => {
-  //     if (error) {
-  //       log.warn(`MetaMask - Account Tracker single call balance fetch failed`, error)
-  //       return Promise.all(addresses.map(this._updateAccount.bind(this)))
-  //     }
-  //     addresses.forEach((address, index) => {
-  //       const balance = bnToHex(result[index])
-  //       accounts[address] = { address, balance }
-  //     })
-  //     this.store.updateState({ accounts })
-  //   })
-  // }
+    try {
+      await ethContract.balances(addresses, ethBalance)
+      addresses.forEach((address, index) => {
+        const balance = bnToHex(result[index])
+        accounts[address] = { address, balance }
+      })
+    } catch (error) {
+      log.warn(`MetaMask - Account Tracker single call balance fetch failed`, error)
+      return Promise.all(addresses.map(this._updateAccount.bind(this)))
+    } finally {
+      this.store.updateState({ accounts })
+    }
+  }
 }
 
 module.exports = AccountTracker

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "github:ethereumjs/ethereumjs-util#ac5d0908536b447083ea422b435da27f26615de9",
     "ethereumjs-wallet": "^0.6.0",
+    "ethers": "^4.0.39",
     "etherscan-link": "^1.0.2",
     "ethjs": "^0.4.0",
     "ethjs-contract": "^0.2.3",

--- a/test/unit/app/controllers/detect-tokens-test.js
+++ b/test/unit/app/controllers/detect-tokens-test.js
@@ -26,10 +26,8 @@ describe('DetectTokensController', () => {
     keyringMemStore = new ObservableStore({ isUnlocked: false})
     network = new NetworkController()
     preferences = new PreferencesController({ network })
-    controller = new DetectTokensController({ preferences: preferences, network: network, keyringMemStore: keyringMemStore })
-
     network.initializeProvider(networkControllerProviderConfig)
-
+    controller = new DetectTokensController({ preferences: preferences, network: network, keyringMemStore: keyringMemStore })
   })
 
   after(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10321,6 +10321,22 @@ ethers@^4.0.20, ethers@^4.0.28:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
+ethers@^4.0.39:
+  version "4.0.39"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.39.tgz#5ce9dfffedb03936415743f63b37d96280886a47"
+  integrity sha512-QVtC8TTUgTrnlQjQvdFJ7fkSWKwp8HVTbKRmrdbVryrPzJHMTf3WSeRNvLF2enGyAFtyHJyFNnjN0fSshcEr9w==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.4"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
 etherscan-link@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/etherscan-link/-/etherscan-link-1.0.2.tgz#c7b9142c4b59509b338a204b6328aea40dd3c64e"


### PR DESCRIPTION
I accidentally removed `web3` from the background by replacing it with `ethers` in the `AccountTracker` and `DetectTokensController`. This could be replicated in the main extension.

`detect-tokens-test.js` fails because of improper mocking of `ethers`, otherwise it looks kind of good to go?
