### PR TITLE
Add ethers to plugin endowments

### DIFF
--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -146,7 +146,7 @@ function getExternalRestrictedMethods (permissionsController) {
           // Here is where we would invoke the message on that plugin iff possible.
           const handler = permissionsController.pluginsController.rpcMessageHandlers.get(origin)
           if (!handler) {
-            res.error = ethErrors.methodNotFound({
+            res.error = ethErrors.rpc.methodNotFound({
               message: `Plugin RPC message handler not found.`, data: req.method,
             })
             return end(res.error)

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -1,6 +1,8 @@
 const ObservableStore = require('obs-store')
 const EventEmitter = require('safe-event-emitter')
 const extend = require('xtend')
+const ethers = require('ethers')
+
 const {
   pluginRestrictedMethodDescriptions,
 } = require('./permissions/restrictedMethods')
@@ -407,6 +409,9 @@ class PluginsController extends EventEmitter {
         setTimeout,
         setInterval,
 
+        // Todo: Remove ethers.js, just for convenience:
+        ethers
+
         // Typed Arrays:
         Int8Array,
         Uint8Array,
@@ -431,6 +436,9 @@ class PluginsController extends EventEmitter {
           // Timers. TODO: Must constrain or remove for production.
           setTimeout,
           setInterval,
+
+          // Todo: Remove ethers.js, just for convenience:
+          ethers
 
           // Typed Arrays:
           Int8Array,

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -402,6 +402,19 @@ class PluginsController extends EventEmitter {
         Buffer,
         Date,
 
+        // Typed Arrays:
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array,
+        BigInt64Array,
+        BigUint64Array,
+
         window: {
           crypto,
           SubtleCrypto,
@@ -409,6 +422,19 @@ class PluginsController extends EventEmitter {
           fetch,
           XMLHttpRequest,
           WebSocket,
+
+          // Typed Arrays:
+          Int8Array,
+          Uint8Array,
+          Uint8ClampedArray,
+          Int16Array,
+          Uint16Array,
+          Int32Array,
+          Uint32Array,
+          Float32Array,
+          Float64Array,
+          BigInt64Array,
+          BigUint64Array,
         },
       })
       sessedPlugin()

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -69,13 +69,14 @@ class PluginsController extends EventEmitter {
 
     Object.values(plugins).forEach(({ pluginName, approvedPermissions, sourceCode }) => {
       console.log(`running: ${pluginName}`)
+      const permissions = approvedPermissions || []
       const ethereumProvider = this.setupProvider({ hostname: pluginName }, async () => {
         return { name: pluginName }
       }, true)
       try {
-        this._startPlugin(pluginName, approvedPermissions, sourceCode, ethereumProvider)
+        this._startPlugin(pluginName, permissions, sourceCode, ethereumProvider)
       } catch (err) {
-        console.warn(`failed to start '${pluginName}', deleting it`)
+        console.warn(`failed to start '${pluginName}', deleting it`, err)
         // Clean up failed plugins:
         this.removePlugin(pluginName)
       }
@@ -402,6 +403,10 @@ class PluginsController extends EventEmitter {
         Buffer,
         Date,
 
+        // Timers. TODO: Must constrain or remove for production.
+        setTimeout,
+        setInterval,
+
         // Typed Arrays:
         Int8Array,
         Uint8Array,
@@ -422,6 +427,10 @@ class PluginsController extends EventEmitter {
           fetch,
           XMLHttpRequest,
           WebSocket,
+
+          // Timers. TODO: Must constrain or remove for production.
+          setTimeout,
+          setInterval,
 
           // Typed Arrays:
           Int8Array,

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -438,7 +438,7 @@ class PluginsController extends EventEmitter {
           setInterval,
 
           // Todo: Remove ethers.js, just for convenience:
-          ethers
+          ethers,
 
           // Typed Arrays:
           Int8Array,

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -410,7 +410,7 @@ class PluginsController extends EventEmitter {
         setInterval,
 
         // Todo: Remove ethers.js, just for convenience:
-        ethers
+        ethers,
 
         // Typed Arrays:
         Int8Array,

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "ethereumjs-tx": "1.3.7",
     "ethereumjs-util": "5.1.0",
     "ethereumjs-wallet": "^0.6.0",
-    "ethers": "^4.0.39",
+    "ethers": "^4.0.40",
     "etherscan-link": "^1.0.2",
     "ethjs": "^0.4.0",
     "ethjs-contract": "^0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9166,6 +9166,19 @@ elliptic@6.3.3:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
+elliptic@6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
+  integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+  dependencies:
+    bn.js "^4.4.0"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    minimalistic-crypto-utils "^1.0.0"
+
 elliptic@=3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-3.0.3.tgz#865c9b420bfbe55006b9f969f97a0d2c44966595"
@@ -10646,15 +10659,14 @@ ethers@^4.0.20, ethers@^4.0.28:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^4.0.39:
-  version "4.0.39"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.39.tgz#5ce9dfffedb03936415743f63b37d96280886a47"
-  integrity sha512-QVtC8TTUgTrnlQjQvdFJ7fkSWKwp8HVTbKRmrdbVryrPzJHMTf3WSeRNvLF2enGyAFtyHJyFNnjN0fSshcEr9w==
+ethers@^4.0.40:
+  version "4.0.40"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.40.tgz#6e1963d10b5d336a13cd81b519c230cc17624653"
+  integrity sha512-MC9BtV7Hpq4dgFONEfanx9aU9GhhoWU270F+/wegHZXA7FR+2KXFdt36YIQYLmVY5ykUWswDxd+f9EVkIa7JOA==
   dependencies:
-    "@types/node" "^10.3.2"
     aes-js "3.0.0"
     bn.js "^4.4.0"
-    elliptic "6.3.3"
+    elliptic "6.5.2"
     hash.js "1.1.3"
     js-sha3 "0.5.7"
     scrypt-js "2.0.4"


### PR DESCRIPTION
Until [we can get ethers.js to operate properly within confinement](https://github.com/MetaMask/metamask-snaps-beta/pull/134), we can provide ethers as a permitted API within plugins, like this.