### PR TITLE
Various fixes and improvements

### DIFF
--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -1,6 +1,10 @@
+
+const pluginPrefix = 'wallet_plugin_'
+
 module.exports = {
   WALLET_PREFIX: 'wallet_',
-  PLUGIN_PREFIX: 'wallet_plugin_',
+  PLUGIN_PREFIX: pluginPrefix,
+  PLUGIN_PREFIX_REGEX: new RegExp(`^${pluginPrefix}`),
   HISTORY_STORE_KEY: 'permissionsHistory',
   LOG_STORE_KEY: 'permissionsLog',
   METADATA_STORE_KEY: 'domainMetadata',

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -24,10 +24,6 @@ const {
   NOTIFICATION_NAMES,
 } = require('./enums')
 
-function prefix (method) {
-  return WALLET_PREFIX + method
-}
-
 // TODO:plugins standardize errors
 const pluginNotInstalledError = serializeError(
   new Error('Plugin permitted but not installed.')
@@ -62,6 +58,15 @@ class PermissionsController {
   // Middleware-related methods
   //=============================================================================
 
+  /**
+   * Create the primary permissions middleware, for use in the extension's RPC
+   * middleware stack.
+   *
+   * @param {Object} opts - The options object.
+   * @param {string} opts.origin - The requesting origin.
+   * @param {string} opts.extensionId - The origin's extensionId, if any.
+   * @param {boolean} opts.isPlugin - Whether the requesting origin is a plugin.
+   */
   createMiddleware ({ origin, extensionId, isPlugin }) {
 
     if (extensionId) {
@@ -100,7 +105,10 @@ class PermissionsController {
   }
 
   /**
-   * Create middleware for prevent non-plugins from accessing methods only available to plugins
+   * Create middleware for prevent non-plugins from accessing methods only
+   * available to plugins.
+   *
+   * @param {boolean} isPlugin - Whether the requesting origin is a plugin.
    */
   createPluginMethodRestrictionMiddleware (isPlugin) {
     return createAsyncMiddleware(async (req, res, next) => {
@@ -150,6 +158,7 @@ class PermissionsController {
 
   /**
    * User approval callback.
+   *
    * @param {object} approved the approved request object
    */
   async approvePermissionsRequest (approved, accounts) {
@@ -178,6 +187,7 @@ class PermissionsController {
 
   /**
    * User rejection callback.
+   *
    * @param {string} id the id of the rejected request
    */
   async rejectPermissionsRequest (id) {
@@ -227,6 +237,7 @@ class PermissionsController {
 
   /**
    * Gets all granted permissions for the given domain, if any.
+   *
    * @param {string} origin - The origin to get permissions for.
    */
   getPermissionsFor (origin) {
@@ -235,6 +246,7 @@ class PermissionsController {
 
   /**
    * Removes the given permissions for the given domain.
+   *
    * @param {object} domains { origin: [permissions] }
    */
   removePermissionsFor (domains) {
@@ -260,6 +272,7 @@ class PermissionsController {
 
   /**
    * Removes all permissions for the given domains.
+   *
    * @param {Array<string>} domainsToDelete - The domains to remove all permissions for.
    */
   removeAllPermissionsFor (domainsToDelete) {
@@ -419,6 +432,10 @@ class PermissionsController {
   //=============================================================================
 
   /**
+   * Install the requested plugins, if the origin has their corresponding
+   * permissions.
+   * For use with the wallet_installPlugins and wallet_enable RPC methods.
+   *
    * @param {string} origin - The external domain id.
    * @param {Object} requestedPlugins - The names of the requested plugin permissions.
    */
@@ -457,6 +474,12 @@ class PermissionsController {
     return result
   }
 
+  /**
+   * Get the permitted plugins for the given origin, by plugin name.
+   * Recall that plugin names !== permission names.
+   *
+   * @param {string} origin - The origin to get the permitted plugins for.
+   */
   getPermittedPlugins (origin) {
 
     return this.getPermissionsFor(origin).reduce(
@@ -612,5 +635,5 @@ class PermissionsController {
 
 module.exports = {
   PermissionsController,
-  addInternalMethodPrefix: prefix,
+  INTERNAL_METHOD_PREFIX: WALLET_PREFIX,
 }

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -58,7 +58,9 @@ class PermissionsController {
     this.getApi = getApi
   }
 
+  //=============================================================================
   // Middleware-related methods
+  //=============================================================================
 
   createMiddleware ({ origin, extensionId, isPlugin }) {
 
@@ -142,7 +144,9 @@ class PermissionsController {
     })
   }
 
+  //=============================================================================
   // Permission-related methods
+  //=============================================================================
 
   /**
    * User approval callback.
@@ -270,7 +274,9 @@ class PermissionsController {
     this.permissions.setDomains(domains)
   }
 
+  //=============================================================================
   // Caveat-related methods
+  //=============================================================================
 
   /**
    * Gets all caveats for the given origin and permission, or returns null
@@ -295,7 +301,9 @@ class PermissionsController {
     return this.permissions.getCaveat(origin, permission, caveatName)
   }
 
+  //=============================================================================
   // Account-related methods
+  //=============================================================================
 
   /**
    * Returns the accounts that should be exposed for the given origin domain,
@@ -406,7 +414,9 @@ class PermissionsController {
     })
   }
 
+  //=============================================================================
   // Plugin-related methods
+  //=============================================================================
 
   /**
    * @param {string} origin - The external domain id.
@@ -466,7 +476,9 @@ class PermissionsController {
     )
   }
 
+  //=============================================================================
   // State-related methods
+  //=============================================================================
 
   /**
    * Removes all known domains and their related permissions.
@@ -497,7 +509,9 @@ class PermissionsController {
     })
   }
 
+  //=============================================================================
   // rpc-cap-related methods
+  //=============================================================================
 
   /**
    * Initializes the underlying CapabilitiesController.

--- a/app/scripts/controllers/permissions/index.js
+++ b/app/scripts/controllers/permissions/index.js
@@ -52,6 +52,8 @@ class PermissionsController {
     this.getApi = getApi
   }
 
+  // Middleware-related methods
+
   createMiddleware ({ origin, extensionId, isPlugin }) {
 
     if (extensionId) {
@@ -71,6 +73,7 @@ class PermissionsController {
       getAccounts: this.getAccounts.bind(this, origin),
       requestPermissions: this._requestPermissions.bind(this, origin),
       installPlugins: this.installPlugins.bind(this),
+      getPlugins: this.getPermittedPlugins.bind(this),
     }))
     engine.push(createLoggerMiddleware({
       walletPrefix: WALLET_PREFIX,
@@ -108,77 +111,8 @@ class PermissionsController {
   }
 
   /**
-   * @param {string} origin - The external domain id.
-   * @param {Object} requestedPlugins - The names of the requested plugin permissions.
-   */
-  async installPlugins (origin, requestedPlugins) {
-
-    const existingPerms = this.permissions.getPermissionsForDomain(origin).reduce(
-      (acc, p) => {
-        acc[p.parentCapability] = true
-        return acc
-      }, {}
-    )
-
-    const result = {}
-
-    // use a for-loop so that we can return an object and await the resolution
-    // of each call to processRequestedPlugin
-    await Promise.all(Object.keys(requestedPlugins).map(async pluginName => {
-
-      const permissionName = PLUGIN_PREFIX + pluginName
-      result[pluginName] = {
-        permission: permissionName,
-      }
-
-      // only allow the installation of permitted plugins
-      if (!existingPerms[permissionName]) {
-
-        result[pluginName].error = ethErrors.provider.unauthorized(
-          `Not authorized to install plugin '${pluginName}'. Please request the permission for the plugin before attempting to install it.`
-        )
-      } else {
-
-        // attempt to install and run the plugin, storing any errors that
-        // occur during the process
-        result[pluginName] = {
-          ...result[pluginName],
-          ...(await this.pluginsController.processRequestedPlugin(pluginName)),
-        }
-      }
-    }))
-    return result
-  }
-
-  /**
-   * Returns the accounts that should be exposed for the given origin domain,
-   * if any. This method exists for when a trusted context needs to know
-   * which accounts are exposed to a given domain.
-   *
-   * Do not use in untrusted contexts; just send an RPC request.
-   *
-   * @param {string} origin
-   */
-  getAccounts (origin) {
-    return new Promise((resolve, _) => {
-      const req = { method: 'eth_accounts' }
-      const res = {}
-      this.permissions.providerMiddlewareFunction(
-        { origin }, req, res, () => {}, _end
-      )
-
-      function _end () {
-        if (res.error || !Array.isArray(res.result)) {
-          resolve([])
-        } else {
-          resolve(res.result)
-        }
-      }
-    })
-  }
-
-  /**
    * Submits a permissions request to rpc-cap. Internal use only.
+   * Other modules should send an RPC request.
    *
    * @param {string} origin - The origin string.
    * @param {IRequestedPermissions} permissions - The requested permissions.
@@ -201,6 +135,8 @@ class PermissionsController {
       }
     })
   }
+
+  // Permission-related methods
 
   /**
    * User approval callback.
@@ -243,6 +179,143 @@ class PermissionsController {
     }
 
     approval.reject(false)
+  }
+
+  /**
+   * Finalizes a permissions request.
+   * Throws if request validation fails.
+   *
+   * @param {Object} requestedPermissions - The requested permissions.
+   * @param {string[]} accounts - The accounts to expose, if any.
+   */
+  async finalizePermissionsRequest (requestedPermissions, accounts) {
+
+    const { eth_accounts: ethAccounts } = requestedPermissions
+
+    if (ethAccounts) {
+
+      await this.validateExposedAccounts(accounts)
+
+      if (!ethAccounts.caveats) {
+        ethAccounts.caveats = []
+      }
+
+      // caveat names are unique, and we will only construct this caveat here
+      ethAccounts.caveats = ethAccounts.caveats.filter(c => (
+        c.name !== CAVEAT_NAMES.exposedAccounts
+      ))
+
+      ethAccounts.caveats.push(
+        {
+          type: 'filterResponse',
+          value: accounts,
+          name: CAVEAT_NAMES.exposedAccounts,
+        },
+      )
+    }
+  }
+
+  /**
+   * Gets all granted permissions for the given domain, if any.
+   * @param {string} origin - The origin to get permissions for.
+   */
+  getPermissionsFor (origin) {
+    return this.permissions.getPermissionsForDomain(origin)
+  }
+
+  /**
+   * Removes the given permissions for the given domain.
+   * @param {object} domains { origin: [permissions] }
+   */
+  removePermissionsFor (domains) {
+
+    Object.entries(domains).forEach(([origin, perms]) => {
+
+      this.permissions.removePermissionsFor(
+        origin,
+        perms.map(methodName => {
+
+          if (methodName === 'eth_accounts') {
+            this.notifyDomain(
+              origin,
+              { method: NOTIFICATION_NAMES.accountsChanged, result: [] }
+            )
+          }
+
+          return { parentCapability: methodName }
+        })
+      )
+    })
+  }
+
+  /**
+   * Removes all permissions for the given domains.
+   * @param {Array<string>} domainsToDelete - The domains to remove all permissions for.
+   */
+  removeAllPermissionsFor (domainsToDelete) {
+    const domains = this.permissions.getDomains()
+    domainsToDelete.forEach(d => {
+      delete domains[d]
+      this.notifyDomain(d, {
+        method: NOTIFICATION_NAMES.accountsChanged,
+        result: [],
+      })
+    })
+    this.permissions.setDomains(domains)
+  }
+
+  // Caveat-related methods
+
+  /**
+   * Gets all caveats for the given origin and permission, or returns null
+   * if none exist.
+   *
+   * @param {string} permission - The name of the target permission.
+   * @param {string} origin - The origin that has the permission.
+   */
+  getCaveatsFor (permission, origin) {
+    return this.permissions.getCaveats(origin, permission) || null
+  }
+
+  /**
+   * Gets the caveat with the given name for the given permission of the
+   * given origin.
+   *
+   * @param {string} permission - The name of the target permission.
+   * @param {string} origin - The origin that has the permission.
+   * @param {string} caveatName - The name of the caveat to retrieve.
+   */
+  getCaveat (permission, origin, caveatName) {
+    return this.permissions.getCaveat(origin, permission, caveatName)
+  }
+
+  // Account-related methods
+
+  /**
+   * Returns the accounts that should be exposed for the given origin domain,
+   * if any. This method exists for when a trusted context needs to know
+   * which accounts are exposed to a given domain.
+   *
+   * Do not use in untrusted contexts; just send an RPC request.
+   *
+   * @param {string} origin
+   */
+  getAccounts (origin) {
+    return new Promise((resolve, _) => {
+      const req = { method: 'eth_accounts' }
+      const res = {}
+      this.permissions.providerMiddlewareFunction(
+        { origin }, req, res, () => {}, _end
+      )
+
+      function _end () {
+        if (res.error || !Array.isArray(res.result)) {
+          resolve([])
+        } else {
+          resolve(res.result)
+        }
+      }
+    })
   }
 
   /**
@@ -307,40 +380,6 @@ class PermissionsController {
   }
 
   /**
-   * Finalizes a permissions request.
-   * Throws if request validation fails.
-   *
-   * @param {Object} requestedPermissions - The requested permissions.
-   * @param {string[]} accounts - The accounts to expose, if any.
-   */
-  async finalizePermissionsRequest (requestedPermissions, accounts) {
-
-    const { eth_accounts: ethAccounts } = requestedPermissions
-
-    if (ethAccounts) {
-
-      await this.validateExposedAccounts(accounts)
-
-      if (!ethAccounts.caveats) {
-        ethAccounts.caveats = []
-      }
-
-      // caveat names are unique, and we will only construct this caveat here
-      ethAccounts.caveats = ethAccounts.caveats.filter(c => (
-        c.name !== CAVEAT_NAMES.exposedAccounts
-      ))
-
-      ethAccounts.caveats.push(
-        {
-          type: 'filterResponse',
-          value: accounts,
-          name: CAVEAT_NAMES.exposedAccounts,
-        },
-      )
-    }
-  }
-
-  /**
    * Validate an array of accounts representing accounts to be exposed
    * to a domain. Throws error if validation fails.
    *
@@ -361,69 +400,69 @@ class PermissionsController {
     })
   }
 
-  /**
-   * Removes the given permissions for the given domain.
-   * @param {object} domains { origin: [permissions] }
-   */
-  removePermissionsFor (domains) {
-
-    Object.entries(domains).forEach(([origin, perms]) => {
-
-      this.permissions.removePermissionsFor(
-        origin,
-        perms.map(methodName => {
-
-          if (methodName === 'eth_accounts') {
-            this.notifyDomain(
-              origin,
-              { method: NOTIFICATION_NAMES.accountsChanged, result: [] }
-            )
-          }
-
-          return { parentCapability: methodName }
-        })
-      )
-    })
-  }
+  // Plugin-related methods
 
   /**
-   * Removes all permissions for the given domains.
-   * @param {Array<string>} domainsToDelete - The domains to remove all permissions for.
+   * @param {string} origin - The external domain id.
+   * @param {Object} requestedPlugins - The names of the requested plugin permissions.
    */
-  removeAllPermissionsFor (domainsToDelete) {
-    const domains = this.permissions.getDomains()
-    domainsToDelete.forEach(d => {
-      delete domains[d]
-      this.notifyDomain(d, {
-        method: NOTIFICATION_NAMES.accountsChanged,
-        result: [],
-      })
-    })
-    this.permissions.setDomains(domains)
+  async installPlugins (origin, requestedPlugins) {
+
+    const existingPerms = this.getPermissionsFor(origin).reduce(
+      (acc, p) => {
+        acc[p.parentCapability] = true
+        return acc
+      }, {}
+    )
+
+    const result = {}
+
+    // use a for-loop so that we can return an object and await the resolution
+    // of each call to processRequestedPlugin
+    await Promise.all(Object.keys(requestedPlugins).map(async pluginName => {
+
+      const permissionName = PLUGIN_PREFIX + pluginName
+
+      // only allow the installation of permitted plugins
+      if (!existingPerms[permissionName]) {
+
+        result[pluginName].error = ethErrors.provider.unauthorized(
+          `Not authorized to install plugin '${pluginName}'. Please request the permission for the plugin before attempting to install it.`
+        )
+      } else {
+
+        // attempt to install and run the plugin, storing any errors that
+        // occur during the process
+        result[pluginName] = {
+          ...(await this.pluginsController.processRequestedPlugin(pluginName)),
+        }
+      }
+    }))
+    return result
   }
 
-  /**
-   * Gets all caveats for the given origin and permission, or returns null
-   * if none exist.
-   *
-   * @param {string} permission - The name of the target permission.
-   * @param {string} origin - The origin that has the permission.
-   */
-  getCaveatsFor (permission, origin) {
-    return this.permissions.getCaveats(origin, permission) || null
+  async getPermittedPlugins (origin) {
+
+    const pluginPrefixRegex = new RegExp(`^${PLUGIN_PREFIX}`)
+
+    return this.getPermissionsFor(origin).reduce(
+      (acc, p) => {
+
+        if (p.parentCapability.startsWith(pluginPrefix)) {
+
+          const pluginName = p.parentCapability.replace(pluginPrefixRegex, '')
+          const plugin = this.pluginsController.getSerializable(pluginName)
+
+          acc[pluginName] = plugin
+            ? plugin
+            : { error: new Error('Plugin permitted but not installed.')}
+        }
+        return acc
+      }, {}
+    )
   }
 
-  /**
-   * Gets the caveat with the given name for the given permission of the
-   * given origin.
-   *
-   * @param {string} permission - The name of the target permission.
-   * @param {string} origin - The origin that has the permission.
-   * @param {string} caveatName - The name of the caveat to retrieve.
-   */
-  getCaveat (permission, origin, caveatName) {
-    return this.permissions.getCaveat(origin, permission, caveatName)
-  }
+  // State-related methods
 
   /**
    * Removes all known domains and their related permissions.
@@ -453,6 +492,8 @@ class PermissionsController {
       [HISTORY_STORE_KEY]: {},
     })
   }
+
+  // rpc-cap-related methods
 
   /**
    * Initializes the underlying CapabilitiesController.
@@ -549,7 +590,6 @@ class PermissionsController {
       },
     }, initState)
   }
-
 }
 
 module.exports = {

--- a/app/scripts/controllers/permissions/loggerMiddleware.js
+++ b/app/scripts/controllers/permissions/loggerMiddleware.js
@@ -9,12 +9,13 @@ const LOG_LIMIT = 100
  * permissions-related methods.
  */
 module.exports = function createLoggerMiddleware ({
-  walletPrefix, restrictedMethods, store, logStoreKey, historyStoreKey,
+  origin, walletPrefix, restrictedMethods, store,
+  logStoreKey, historyStoreKey,
 }) {
   return (req, res, next, _end) => {
 
     let activityEntry, requestedMethods
-    const { origin, method } = req
+    const { method } = req
     const isInternal = method.startsWith(walletPrefix)
 
     if (isInternal || restrictedMethods.includes(method)) {
@@ -41,7 +42,7 @@ module.exports = function createLoggerMiddleware ({
       id: request.id,
       method: request.method,
       methodType: isInternal ? 'internal' : 'restricted',
-      origin: request.origin,
+      origin,
       request: cloneObj(request),
       requestTime: Date.now(),
       response: null,
@@ -109,7 +110,7 @@ module.exports = function createLoggerMiddleware ({
     }
   }
 
-  function commitHistory (origin, entries, accounts) {
+  function commitHistory (entries, accounts) {
 
     const history = store.getState()[historyStoreKey]
 

--- a/app/scripts/controllers/permissions/methodMiddleware.js
+++ b/app/scripts/controllers/permissions/methodMiddleware.js
@@ -329,7 +329,9 @@ module.exports = function createRequestMiddleware ({
   }
 
   /**
+   * Saves the metadata for this middleware's origin.
    *
+   * @param {Object} metadata - The metadata.
    */
   function saveDomainMetadata (metadata) {
 

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -1,6 +1,7 @@
 
 const { ethErrors } = require('eth-json-rpc-errors')
 
+// ATTN: this list determines which internal API methods a plugin can actually use
 const pluginRestrictedMethodDescriptions = {
   onNewTx: 'Take action whenever a new transaction is created',
   fetch: 'Retrieve data from external sites',
@@ -52,7 +53,6 @@ const pluginRestrictedMethodDescriptions = {
   setSelectedAddress: 'Set the currently-selected address',
   setUseBlockie: 'Toggle the Blockie identicon format',
   submitPassword: 'Submits the user password and attempts to unlock the vault. This will not be included in production.',
-  unMarkPasswordForgotten: 'Allows a user to end the seed phrase recovery process',
   unlockHardwareWalletAccount: 'Imports an account from a Trezor device',
   updateAndSetCustomRpc: 'Select a custom URL for an Ethereum RPC provider and updating it',
   verifySeedPhrase: 'Verifies the validity of the current vault seed phrase',

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -146,7 +146,7 @@ function getExternalRestrictedMethods (permissionsController) {
           // Here is where we would invoke the message on that plugin iff possible.
           const handler = permissionsController.pluginsController.rpcMessageHandlers.get(origin)
           if (!handler) {
-            res.error = ethErrors.methodNotFound({
+            res.error = ethErrors.rpc.methodNotFound({
               message: `Plugin RPC message handler not found.`, data: req.method,
             })
             return end(res.error)

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -292,7 +292,11 @@ class PluginsController extends EventEmitter {
    */
   async processRequestedPlugin (pluginName) {
 
-    let result = {}
+    // if the plugin is already installed and active, just return it
+    const { isActive } = this.get(pluginName)
+    if (isActive) {
+      return { ...this.getSerializable(pluginName) }
+    }
 
     try {
 
@@ -312,15 +316,13 @@ class PluginsController extends EventEmitter {
         pluginName, approvedPermissions, sourceCode, ethereumProvider
       )
 
-      result = this.getSerializable(pluginName)
+      return { ...this.getSerializable(pluginName) }
 
     } catch (err) {
 
       console.warn(`Error when adding plugin:`, err)
-      result.error = serializeError(err)
+      return { error: serializeError(err) }
     }
-
-    return result
   }
 
   /**

--- a/app/scripts/controllers/plugins.js
+++ b/app/scripts/controllers/plugins.js
@@ -60,7 +60,9 @@ class PluginsController extends EventEmitter {
 
     // TODO:SECURITY disable errorStackMode for production
     this.rootRealm = SES.makeSESRootRealm({
-      consoleMode: 'allow', errorStackMode: 'allow', mathRandomMode: 'allow',
+      consoleMode: 'allow',
+      errorStackMode: 'allow',
+      mathRandomMode: 'allow',
     })
 
     this.setupProvider = opts.setupProvider
@@ -293,8 +295,8 @@ class PluginsController extends EventEmitter {
   async processRequestedPlugin (pluginName) {
 
     // if the plugin is already installed and active, just return it
-    const { isActive } = this.get(pluginName)
-    if (isActive) {
+    const plugin = this.get(pluginName)
+    if (plugin && plugin.isActive) {
       return { ...this.getSerializable(pluginName) }
     }
 

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -1,5 +1,5 @@
 const ObservableStore = require('obs-store')
-const { addInternalMethodPrefix } = require('./permissions')
+const { INTERNAL_METHOD_PREFIX } = require('./permissions')
 const normalizeAddress = require('eth-sig-util').normalize
 const { isValidAddress, sha3, bufferToHex } = require('ethereumjs-util')
 const extend = require('xtend')
@@ -190,7 +190,7 @@ class PreferencesController {
   async requestWatchAsset (req, res, next, end) {
     if (
       req.method === 'metamask_watchAsset' ||
-      req.method === addInternalMethodPrefix('watchAsset')
+      req.method === INTERNAL_METHOD_PREFIX + 'watchAsset'
     ) {
       const { type, options } = req.params
       switch (type) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -306,6 +306,7 @@ module.exports = class MetamaskController extends EventEmitter {
       _blockTracker: this.blockTracker,
       _getAccounts: this.keyringController.getAccounts.bind(this.keyringController),
       _removeAllPermissionsFor: this.permissionsController.removeAllPermissionsFor.bind(this.permissionsController),
+      _getPermissionsFor: this.permissionsController.getPermissionsFor.bind(this.permissionsController),
       getApi: this.getPluginsApi.bind(this),
       initState: initState.PluginsController,
       getAppKeyForDomain: this.getAppKeyForDomain.bind(this),
@@ -1658,9 +1659,9 @@ module.exports = class MetamaskController extends EventEmitter {
     )
   }
 
-  setupProvider (senderUrl, getSiteMetadata, isPlugin) {
+  setupProvider (senderUrl, getDomainMetadata, isPlugin) {
     const { clientSide, serverSide } = makeDuplexPair()
-    this.setupUntrustedCommunication(serverSide, senderUrl, getSiteMetadata, isPlugin)
+    this.setupUntrustedCommunication(serverSide, senderUrl, getDomainMetadata, isPlugin)
     const provider = new MetamaskInpageProvider(clientSide)
     return provider
   }

--- a/test/unit/app/controllers/preferences-controller-test.js
+++ b/test/unit/app/controllers/preferences-controller-test.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const ObservableStore = require('obs-store')
 const PreferencesController = require('../../../../app/scripts/controllers/preferences')
-const { addInternalMethodPrefix } = require('../../../../app/scripts/controllers/permissions')
+const { INTERNAL_METHOD_PREFIX } = require('../../../../app/scripts/controllers/permissions')
 const sinon = require('sinon')
 
 describe('preferences controller', function () {
@@ -376,7 +376,7 @@ describe('preferences controller', function () {
       await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
       sandbox.assert.called(stubEnd)
       sandbox.assert.notCalled(stubNext)
-      req.method = addInternalMethodPrefix('watchAsset')
+      req.method = INTERNAL_METHOD_PREFIX + 'watchAsset'
       req.params.type = 'someasset'
       await preferencesController.requestWatchAsset(req, res, asy.next, asy.end)
       sandbox.assert.calledTwice(stubEnd)

--- a/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -7,7 +7,7 @@ export default class PermissionPageContainerContent extends PureComponent {
 
   static propTypes = {
     requestMetadata: PropTypes.object.isRequired,
-    siteMetadata: PropTypes.object.isRequired,
+    domainMetadata: PropTypes.object.isRequired,
     selectedPermissions: PropTypes.object.isRequired,
     permissionsDescriptions: PropTypes.object.isRequired,
     onPermissionToggle: PropTypes.func.isRequired,
@@ -25,24 +25,24 @@ export default class PermissionPageContainerContent extends PureComponent {
 
   renderPermissionApprovalVisual = () => {
     const {
-      requestMetadata, siteMetadata, selectedAccount, onAccountSelect,
+      requestMetadata, domainMetadata, selectedAccount, onAccountSelect,
     } = this.props
 
     return (
       <div className="permission-approval-visual">
         <section>
-          {!this.state.iconError && siteMetadata.icon ? (
+          {!this.state.iconError && domainMetadata.icon ? (
             <img
               className="permission-approval-visual__identicon"
-              src={siteMetadata.icon}
+              src={domainMetadata.icon}
               onError={() => this.setState({ iconError: true })}
             />
           ) : (
             <i className="permission-approval-visual__identicon--default">
-              {siteMetadata.name.charAt(0).toUpperCase()}
+              {domainMetadata.name.charAt(0).toUpperCase()}
             </i>
           )}
-          <h1>{siteMetadata.name}</h1>
+          <h1>{domainMetadata.name}</h1>
           <h2>{requestMetadata.origin}</h2>
         </section>
         <span className="permission-approval-visual__check" />
@@ -99,7 +99,7 @@ export default class PermissionPageContainerContent extends PureComponent {
   }
 
   render () {
-    const { siteMetadata } = this.props
+    const { domainMetadata } = this.props
     const { t } = this.context
 
     // TODO:lps change the learnMore link
@@ -109,7 +109,7 @@ export default class PermissionPageContainerContent extends PureComponent {
           <h2>{t('permissionsRequest')}</h2>
           {this.renderPermissionApprovalVisual()}
           <section>
-            <h1>{siteMetadata.name}</h1>
+            <h1>{domainMetadata.name}</h1>
             <h2>Would like to:</h2>
             {this.renderRequestedPermissions()}
             <br/>

--- a/ui/app/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.component.js
@@ -10,7 +10,7 @@ export default class PermissionPageContainer extends Component {
     rejectPermissionsRequest: PropTypes.func.isRequired,
     selectedIdentity: PropTypes.object.isRequired,
     permissionsDescriptions: PropTypes.object.isRequired,
-    siteMetadata: PropTypes.object.isRequired,
+    domainMetadata: PropTypes.object.isRequired,
     requests: PropTypes.array.isRequired,
     showLoadingIndication: PropTypes.func.isRequired,
     hideLoadingIndication: PropTypes.func.isRequired,
@@ -129,13 +129,13 @@ export default class PermissionPageContainer extends Component {
   }
 
   render () {
-    const { requests, permissionsDescriptions, siteMetadata } = this.props
+    const { requests, permissionsDescriptions, domainMetadata } = this.props
     console.log('permission-page-container requests', requests)
 
     const requestMetadata = requests[0].metadata
 
-    const targetSiteMetadata = (
-      siteMetadata[requestMetadata.origin] ||
+    const targetDomainMetadata = (
+      domainMetadata[requestMetadata.origin] ||
       { name: requestMetadata.origin, icon: null }
     )
 
@@ -144,7 +144,7 @@ export default class PermissionPageContainer extends Component {
         <PermissionPageContainerHeader />
         <PermissionPageContainerContent
           requestMetadata={requestMetadata}
-          siteMetadata={targetSiteMetadata}
+          domainMetadata={targetDomainMetadata}
           selectedPermissions={this.state.selectedPermissions}
           permissionsDescriptions={permissionsDescriptions}
           onPermissionToggle={this.onPermissionToggle}

--- a/ui/app/components/app/permission-page-container/permission-page-container.container.js
+++ b/ui/app/components/app/permission-page-container/permission-page-container.container.js
@@ -4,7 +4,7 @@ import {
   getSelectedIdentity,
   getPermissionsDescriptions,
   getPermissionsRequests,
-  getSiteMetadata,
+  getDomainMetadata,
 } from '../../../selectors/selectors'
 import { hideLoadingIndication, showLoadingIndication } from '../../../store/actions'
 
@@ -45,7 +45,7 @@ const mapStateToProps = (state) => {
     requests,
     selectedIdentity: getSelectedIdentity(state),
     permissionsDescriptions: requestedPermissionsDescriptions,
-    siteMetadata: getSiteMetadata(state),
+    domainMetadata: getDomainMetadata(state),
   }
 }
 

--- a/ui/app/pages/settings/permissions-tab/permissions-list/permissions-list.component.js
+++ b/ui/app/pages/settings/permissions-tab/permissions-list/permissions-list.component.js
@@ -11,7 +11,7 @@ export default class PermissionsList extends Component {
     permissions: PropTypes.object.isRequired,
     permissionsDescriptions: PropTypes.object.isRequired,
     removePermissionsFor: PropTypes.func.isRequired,
-    siteMetadata: PropTypes.object,
+    domainMetadata: PropTypes.object,
   }
 
   static contextTypes = {
@@ -135,7 +135,7 @@ export default class PermissionsList extends Component {
   }
 
   renderPermissionsList () {
-    const { permissions, permissionsDescriptions, siteMetadata } = this.props
+    const { permissions, permissionsDescriptions, domainMetadata } = this.props
     return (
       <ul>
         {
@@ -148,7 +148,7 @@ export default class PermissionsList extends Component {
             }
 
             const targetMetadata = (
-              siteMetadata[domain] ||
+              domainMetadata[domain] ||
               { name: domain, icon: null }
             )
 

--- a/ui/app/pages/settings/permissions-tab/permissions-tab.component.js
+++ b/ui/app/pages/settings/permissions-tab/permissions-tab.component.js
@@ -17,7 +17,7 @@ export default class PermissionsTab extends Component {
     showClearPermissionsModal: PropTypes.func.isRequired,
     showClearPermissionsActivityModal: PropTypes.func.isRequired,
     showClearPermissionsHistoryModal: PropTypes.func.isRequired,
-    siteMetadata: PropTypes.object,
+    domainMetadata: PropTypes.object,
   }
 
   static contextTypes = {
@@ -67,7 +67,7 @@ export default class PermissionsTab extends Component {
           permissions={this.props.permissions}
           permissionsDescriptions={this.props.permissionsDescriptions}
           removePermissionsFor={this.props.removePermissionsFor}
-          siteMetadata={this.props.siteMetadata}
+          domainMetadata={this.props.domainMetadata}
         />
         {
           this.renderClearButton(

--- a/ui/app/pages/settings/permissions-tab/permissions-tab.container.js
+++ b/ui/app/pages/settings/permissions-tab/permissions-tab.container.js
@@ -9,7 +9,7 @@ import {
 import {
   getAllPermissions,
   getPermissionsDescriptions,
-  getSiteMetadata,
+  getDomainMetadata,
   getPermissionsHistory,
   getPermissionsLog,
 } from '../../../selectors/selectors'
@@ -21,7 +21,7 @@ const mapStateToProps = state => {
     warning,
     permissions: getAllPermissions(state),
     permissionsDescriptions: getPermissionsDescriptions(state),
-    siteMetadata: getSiteMetadata(state),
+    domainMetadata: getDomainMetadata(state),
     permissionsHistory: getPermissionsHistory(state),
     permissionsLog: getPermissionsLog(state),
   }

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -57,7 +57,7 @@ const selectors = {
   getPermissionsDescriptions,
   getPermissionsHistory,
   getPermissionsLog,
-  getSiteMetadata,
+  getDomainMetadata,
   getActiveTab,
   getMetaMetricState,
   getRpcPrefsForCurrentProvider,
@@ -377,8 +377,8 @@ function getPermissionsLog (state) {
   return state.metamask.permissionsLog || {}
 }
 
-function getSiteMetadata (state) {
-  return state.metamask.siteMetadata || {}
+function getDomainMetadata (state) {
+  return state.metamask.domainMetadata || {}
 }
 
 function getActiveTab (state) {

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2794,6 +2794,7 @@ function clearAllPermissionsData () {
     background.clearPermissions()
     background.clearPermissionsHistory()
     background.clearPermissionsLog()
+    background.clearDomainMetadata()
   }
 }
 


### PR DESCRIPTION
Fixes #5, Fixes #68, Fixes #99, Fixes #138

### Changes in Detail

- Add `wallet_getPlugins` RPC method
  - This returns metadata about permitted plugins to the caller
  - Indicates whether plugins are installed or not
- `PermissionsController`
  - _Do not reinstall plugins if they're already installed_
    - _At this point in beta, plugins should just be removed using the buttons we expose before reinstalling them_
  - New methods: `getPermittedPlugins`, `clearDomainMetadata`
  - Improve section demarcation/commenting
- `PluginsController`
  - _Add teardown for plugin `onMetaMaskEvent` listeners_
    - _We weren't removing these event listeners previously!_
    - _Added new methods:_ `_removeAllMetaMaskEventListeners`, `_removeAllMetaMaskEventListeners`
    - _Extensively modified:_ `_createMetaMaskEventListener`, `_generateMetaMaskListenerMethodsMap`, `_eventEmitterToListenerMap`
  - _Add doc comments for all but the most trivial internal methods_
    - _This is where much/most of the diff comes from_
  - Stop storing `plugin.approvedPermissions`
    - Always get current plugin permissions from `PermissionsController`
    - Does not affect `initialPermissions`
  - New method: `getSerializable` for getting plugins without getting e.g. their source code
- Tear down plugin providers
  - See method `closeAllConnections` in `metamask-controller.js` and its use in `PluginsController`
- Miscellaneous
  - Return `userRejectedRequest` error from `wallet_enable` if no permissions were granted
  - Rename `siteMetadata` to `domainMetadata` everywhere
    - To reflect that it can refer to not just sites, but also plugins, and who knows what else in the future
