### PR TITLE
Clear address audit state when clearing permissions state

### DIFF
--- a/app/scripts/controllers/address-audit.js
+++ b/app/scripts/controllers/address-audit.js
@@ -39,8 +39,8 @@ class AddressAuditController {
     })
   }
 
-  clearAudits () {
-    this.store.updateState({ audits: {} })
+  clearState () {
+    this.store.updateState({ addressAudits: {} })
   }
 
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -638,6 +638,9 @@ module.exports = class MetamaskController extends EventEmitter {
       removePlugin: this.pluginsController.removePlugin.bind(this.pluginsController),
       removePlugins: this.pluginsController.removePlugins.bind(this.pluginsController),
       clearPluginState: this.pluginsController.clearState.bind(this.pluginsController),
+
+      // address audit controller
+      clearAddressAudits: this.addressAuditController.clearState.bind(this.addressAuditController),
     }
   }
 

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2795,6 +2795,7 @@ function clearAllPermissionsData () {
     background.clearPermissionsHistory()
     background.clearPermissionsLog()
     background.clearDomainMetadata()
+    background.clearAddressAudits()
   }
 }
 


### PR DESCRIPTION
We had a method for clearing the address audit controller's state, but were not calling it anywhere.  In addition, the clear function was using an incorrect storage key.

This PR ensures that the address audit controller's state is cleared when the permissions controller state is clear. It's an open question whether we should do it there or elsewhere.

cc: @danjm @danfinlay 