### PR TITLE
Add account types

### DIFF
--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -34,6 +34,9 @@ class AccountsController extends EventEmitter {
 
   async getAccounts () {
     const keyAccounts = await this.keyringController.getAccounts()
+    keyAccounts.forEach((key) => {
+      key.type = 'bip44:60'
+    })
     const pluginAccounts = await this.getPluginAccounts()
     return [...keyAccounts, ...pluginAccounts]
   }
@@ -84,6 +87,14 @@ class AccountsController extends EventEmitter {
         throw e
       }
     }
+  }
+
+  async sendMessage (opts) {
+    if (!opts.from) {
+      throw new Error('From is a required field.')
+    }
+    const handler = getHandlerForAccount(opts.from)
+    return handler(this.getOrigin(address), opts)
   }
 
   async fullUpdate () {

--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -35,7 +35,7 @@ class AccountsController extends EventEmitter {
   async getAccounts () {
     const keyAccounts = await this.keyringController.getAccounts()
     keyAccounts.forEach((key) => {
-      key.type = 'bip44:60'
+      key.type = 'slip44:60'
     })
     const pluginAccounts = await this.getPluginAccounts()
     return [...keyAccounts, ...pluginAccounts]

--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -32,17 +32,18 @@ class AccountsController extends EventEmitter {
     })
   }
 
+  // This is really more of a "get ether addresses" method,
+  // the naming is legacy compatability with `eth-keyring-controller`.
   async getAccounts () {
     const keyAccounts = await this.keyringController.getAccounts()
-    keyAccounts.forEach((key) => {
-      key.type = 'slip44:60'
-    })
-    const pluginAccounts = await this.getPluginAccounts()
+    const pluginAccounts = await this.getEtherPluginAccounts()
     return [...keyAccounts, ...pluginAccounts]
   }
 
-  async getPluginAccounts () {
-    return this.pluginAccounts.resources.map(acct => acct.address)
+  async getEtherPluginAccounts () {
+    return this.pluginAccounts.resources
+      .filter(acct => acct.type === 'Ether')
+      .map(acct => acct.address)
   }
 
   async exportAccount (address) {

--- a/app/scripts/controllers/accounts.js
+++ b/app/scripts/controllers/accounts.js
@@ -93,8 +93,8 @@ class AccountsController extends EventEmitter {
     if (!opts.from) {
       throw new Error('From is a required field.')
     }
-    const handler = getHandlerForAccount(opts.from)
-    return handler(this.getOrigin(address), opts)
+    const handler = this.getHandlerForAccount(opts.from)
+    return handler(opts)
   }
 
   async fullUpdate () {

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -115,7 +115,6 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
           res.result = pluginAccountsController.resources.filter(acct => acct.type === accountTypeCode)
           end()
         } else {
-          const origin = engine.domain
 
           try {
             res.result = await permissionsController.accountsController.sendMessage(req.params)

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -97,7 +97,7 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
         const methodSegments = req.method.split('_')
         const accountTypeCode = methodSegments[methodSegments.length - 1]
         req.params[1].type = accountTypeCode
-        //TODO: Enforce that snaps can only manage their own accounts.
+        // TODO: Enforce that snaps can only manage their own accounts.
         pluginAccountsController.handleRpcRequest(req, res, _next, end, engine)
       },
     },
@@ -111,23 +111,22 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
 
         // if no params, get accounts
         if (!req.params) {
-          //TODO: Add account selector dialog here.
+          // TODO: Add account selector dialog here.
           res.result = pluginAccountsController.resources.filter(acct => acct.type === accountTypeCode)
           end()
         } else {
           const origin = engine.domain
-          const prior = permissionsController.pluginsController.get(origin)
 
           try {
-            res.result = await permissionsController.accountsController.sendMessage(req.params);
+            res.result = await permissionsController.accountsController.sendMessage(req.params)
           } catch (err) {
-            res.error = err;
-            end(res.error);
+            res.error = err
+            end(res.error)
           }
 
         }
       },
-    }
+    },
 
     'alert': {
       description: 'Show alerts over the current page.',

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -104,7 +104,7 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
 
     'wallet_accounts_*': {
       description: 'View all accounts of type "$1" and suggest interactions related to them.',
-      method: async (req, res, _next, end, engine) => {
+      method: async (req, res, _next, end) => {
         const methodSegments = req.method.split('_')
         const accountTypeCode = methodSegments[methodSegments.length - 1]
         req.params[1].type = accountTypeCode

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -104,7 +104,7 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
 
     'wallet_accounts_*': {
       description: 'View all accounts of type "$1" and suggest interactions related to them.',
-      method: (req, res, _next, end, engine) => {
+      method: async (req, res, _next, end, engine) => {
         const methodSegments = req.method.split('_')
         const accountTypeCode = methodSegments[methodSegments.length - 1]
         req.params[1].type = accountTypeCode

--- a/app/scripts/controllers/permissions/restrictedMethods.js
+++ b/app/scripts/controllers/permissions/restrictedMethods.js
@@ -74,7 +74,9 @@ function getExternalRestrictedMethods (permissionsController, addPrompt) {
       method: (_, res, __, end) => {
         permissionsController.accountsController.getAccounts()
           .then((accounts) => {
-            res.result = accounts
+            res.result = accounts.filter((account) => {
+              return account.type === 'Ether'
+            })
             end()
           })
           .catch((reason) => {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -175,7 +175,7 @@ module.exports = class MetamaskController extends EventEmitter {
     this.keyringController.memStore.subscribe((s) => this._onKeyringControllerUpdate(s))
 
     this.pluginAccountsController = new ResourceController({
-      requiredFields: ['address'],
+      requiredFields: ['address', 'type'],
       storageKey: RESOURCE_KEYS.PLUGIN_ACCOUNTS,
     })
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -431,7 +431,7 @@ module.exports = class MetamaskController extends EventEmitter {
         ) {
           const permittedAccounts = await this.permissionsController.getAccounts(origin)
           // TODO: figure out plugin account permissions
-          const pluginAccounts = await this.accountsController.getPluginAccounts()
+          const pluginAccounts = await this.accountsController.getEtherPluginAccounts()
           return [ ...permittedAccounts, ...pluginAccounts ]
         }
         return [] // changing this is a breaking change


### PR DESCRIPTION
Introduces a concept of "account types" to the AccountsController.

The permission to `wallet_manageIdentities` is now known
as `wallet_manageAccounts_*`, where `*` is an account type identifier
string.

Currently this string is `Ether` for Ethereum accounts, [per Ethereum's SLIP44 name](https://github.com/MetaMask/slip44).

Also introduces `wallet_accounts_*`, where `*` is again that same account type
identifier. This method is meant to so that `eth_accounts` can be an
alias for `wallet_accounts_Ether`, as a strict superset of that method.

If any parameters are present in a call to `wallet_accounts_*`, then
those parameters will be passed to the handler for the account defined
by the `from` value on its `AccountMessageHandler` function, allowing
account type snaps to define their own interfaces, and the accounts
permission to allow passing through messages related to the permitted
accounts.

Will benefit from a number of improvements:
- [ ] Rendering protocol names from slip44 identifier.
- [ ] Allow selecting (attenuating) accounts of non-eth protocols.
- [ ] Redirect `eth_accounts` at `wallet_accounts_*`.
- [ ] See if we can redirect all classic eth signing methods through
this new general purpose send method (allows keyrings to iterate faster
than the keyring-controller).